### PR TITLE
Problem: need end-to-end example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Executables
 wap_selftest
+wap_tutorial
 *.exe
 *.out
 *.app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,10 @@ set (wallet_headers
     include/wap_library.h
     include/wallet.h
     include/wap_proto.h
+    include/wap_server.h
+    include/wap_client.h
+    src/wap_server_engine.inc
+    src/wap_client_engine.inc
 )
 source_group ("Header Files" FILES ${wallet_headers})
 install(FILES ${wallet_headers} DESTINATION include)
@@ -104,6 +108,8 @@ include_directories(${BINARY_DIR})
 include_directories(${SOURCE_DIR}/include)
 set (wallet_sources
     src/wap_proto.c
+    src/wap_server.c
+    src/wap_client.c
 )
 source_group ("Source Files" FILES ${wallet_sources})
 add_library(wallet SHARED ${wallet_sources})

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,8 @@ bin_PROGRAMS =
 check_PROGRAMS =
 
 EXTRA_DIST = \
+    wap_server_engine.inc \
+    wap_client_engine.inc \
     version.sh
 
 include $(srcdir)/src/Makemodule.am

--- a/builds/android/Android.mk
+++ b/builds/android/Android.mk
@@ -20,7 +20,7 @@ include $(PREBUILT_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := wallet
 LOCAL_C_INCLUDES := ../../include $(LIBZMQ)/include
-LOCAL_SRC_FILES := wap_proto.c
+LOCAL_SRC_FILES := wap_proto.c wap_server.c wap_client.c
 LOCAL_SHARED_LIBRARIES := zmq
 include $(BUILD_SHARED_LIBRARY)
 

--- a/builds/mingw32/Makefile.mingw32
+++ b/builds/mingw32/Makefile.mingw32
@@ -10,7 +10,7 @@ INCDIR=-I$(PREFIX)/include -I.
 LIBDIR=-L$(PREFIX)/lib
 CFLAGS=-Wall -Os -g -DLIBWAP_EXPORTS $(INCDIR)
 
-OBJS = wap_proto.o
+OBJS = wap_proto.o wap_server.o wap_client.o
 %.o: ../../src/%.c
 	$(CC) -c -o $@ $< $(CFLAGS)
 

--- a/builds/msvc/vs2008/wallet/wallet.vcproj
+++ b/builds/msvc/vs2008/wallet/wallet.vcproj
@@ -230,12 +230,80 @@
           <Tool Name="VCCLCompilerTool" CompileAs="2" />
         </FileConfiguration>
       </File>
+      <File RelativePath="..\..\..\..\src\wap_server.c">
+        <FileConfiguration Name="Release|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Release|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+      </File>
+      <File RelativePath="..\..\..\..\src\wap_client.c">
+        <FileConfiguration Name="Release|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Release|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="Debug|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="DebugDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="ReleaseDLL|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|Win32">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+        <FileConfiguration Name="RelWithDebInfo|x64">
+          <Tool Name="VCCLCompilerTool" CompileAs="2" />
+        </FileConfiguration>
+      </File>
     </Filter>
     <Filter Name="Header Files">
       <File RelativePath="..\..\..\..\builds\msvc\platform.h" />
       <File RelativePath="..\..\..\..\include\wap_proto.h" />
+      <File RelativePath="..\..\..\..\include\wap_server.h" />
+      <File RelativePath="..\..\..\..\include\wap_client.h" />
       <File RelativePath="..\..\..\..\include\wap_library.h" />
       <File RelativePath="..\..\..\..\include\wallet.h" />
+      <File RelativePath="..\..\..\..\src\wap_server_engine.inc" />
+      <File RelativePath="..\..\..\..\src\wap_client_engine.inc" />
     </Filter>
   </Files>
   <Globals />

--- a/builds/msvc/vs2010/wallet/wallet.vcxproj
+++ b/builds/msvc/vs2010/wallet/wallet.vcxproj
@@ -79,9 +79,17 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h" />
     <ClInclude Include="..\..\..\..\include\wallet.h" />
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc" />
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
   </ItemGroup>

--- a/builds/msvc/vs2010/wallet/wallet.vcxproj.filters
+++ b/builds/msvc/vs2010/wallet/wallet.vcxproj.filters
@@ -10,6 +10,12 @@
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h">
@@ -17,6 +23,12 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\wallet.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc">
+      <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/builds/msvc/vs2012/wallet/wallet.vcxproj
+++ b/builds/msvc/vs2012/wallet/wallet.vcxproj
@@ -79,9 +79,17 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h" />
     <ClInclude Include="..\..\..\..\include\wallet.h" />
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc" />
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
   </ItemGroup>

--- a/builds/msvc/vs2012/wallet/wallet.vcxproj.filters
+++ b/builds/msvc/vs2012/wallet/wallet.vcxproj.filters
@@ -10,6 +10,12 @@
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h">
@@ -17,6 +23,12 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\wallet.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc">
+      <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/builds/msvc/vs2013/wallet/wallet.vcxproj
+++ b/builds/msvc/vs2013/wallet/wallet.vcxproj
@@ -79,9 +79,17 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h" />
     <ClInclude Include="..\..\..\..\include\wallet.h" />
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc" />
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
   </ItemGroup>

--- a/builds/msvc/vs2013/wallet/wallet.vcxproj.filters
+++ b/builds/msvc/vs2013/wallet/wallet.vcxproj.filters
@@ -10,6 +10,12 @@
     <ClCompile Include="..\..\..\..\src\wap_proto.c">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_server.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\wap_client.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\wap_library.h">
@@ -17,6 +23,12 @@
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\wallet.h">
       <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_server_engine.inc">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\wap_client_engine.inc">
+      <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,7 @@
 #  Please refer to the README for information about making permanent changes.  #
 ################################################################################
 MAN1 =
-MAN3 = wap_proto.3
+MAN3 = wap_proto.3 wap_server.3 wap_client.3
 MAN7 = wallet.7
 MAN_DOC = $(MAN1) $(MAN3) $(MAN7)
 
@@ -35,6 +35,10 @@ SUFFIXES=.txt .xml .1 .3 .7
 	xmlto man $<
 
 wap_proto.txt:
+	zproject_mkman $<
+wap_server.txt:
+	zproject_mkman $<
+wap_client.txt:
 	zproject_mkman $<
 endif
 ################################################################################

--- a/doc/wap_client.doc
+++ b/doc/wap_client.doc
@@ -1,0 +1,76 @@
+#### wap_client - Wallet Client API
+
+Description of class for man page.
+
+Detailed discussion of the class, if any.
+
+This is the class interface:
+
+    //  Create a new wap_client
+    //  Connect to server endpoint, with specified timeout in msecs (zero means wait    
+    //  forever). Constructor succeeds if connection is successful. The caller may      
+    //  specify its address.                                                            
+    WAP_EXPORT wap_client_t *
+        wap_client_new (const char *endpoint, int timeout, const char *address);
+    
+    //  Destroy the wap_client
+    WAP_EXPORT void
+        wap_client_destroy (wap_client_t **self_p);
+    
+    //  Enable verbose logging of client activity
+    WAP_EXPORT void
+        wap_client_verbose (wap_client_t *self);
+    
+    //  Return actor, when caller wants to work with multiple actors and/or
+    //  input sockets asynchronously.
+    WAP_EXPORT zactor_t *
+        wap_client_actor (wap_client_t *self);
+    
+    //  Return message pipe for asynchronous message I/O. In the high-volume case,
+    //  we send methods and get replies to the actor, in a synchronous manner, and
+    //  we send/recv high volume message data to a second pipe, the msgpipe. In
+    //  the low-volume case we can do everything over the actor pipe, if traffic
+    //  is never ambiguous.
+    WAP_EXPORT zsock_t *
+        wap_client_msgpipe (wap_client_t *self);
+    
+    //  Request a set of blocks from the server.                                        
+    //  Returns >= 0 if successful, -1 if interrupted.
+    WAP_EXPORT int
+        wap_client_blocks (wap_client_t *self);
+    
+    //  Return last received status
+    WAP_EXPORT int 
+        wap_client_status (wap_client_t *self);
+    
+    //  Return last received reason
+    WAP_EXPORT const char *
+        wap_client_reason (wap_client_t *self);
+    
+    //  Return last received start_height
+    WAP_EXPORT int 
+        wap_client_start_height (wap_client_t *self);
+    
+    //  Return last received curr_height
+    WAP_EXPORT int 
+        wap_client_curr_height (wap_client_t *self);
+    
+    //  Return last received block_status
+    WAP_EXPORT const char *
+        wap_client_block_status (wap_client_t *self);
+    
+    //  Return last received block_data
+    WAP_EXPORT zmsg_t *
+        wap_client_block_data (wap_client_t *self);
+    
+    //  Self test of this class
+    WAP_EXPORT void
+        wap_client_test (bool verbose);
+
+This is the class self test code:
+
+    zactor_t *client = zactor_new (wap_client, NULL);
+    if (verbose)
+        zstr_send (client, "VERBOSE");
+    zactor_destroy (&client);
+

--- a/doc/wap_client.txt
+++ b/doc/wap_client.txt
@@ -1,0 +1,88 @@
+wap_client(3)
+=============
+
+NAME
+----
+wap_client - Wallet Client API
+
+SYNOPSIS
+--------
+----
+//  Create a new wap_client
+//  Connect to server endpoint, with specified timeout in msecs (zero means wait    
+//  forever). Constructor succeeds if connection is successful. The caller may      
+//  specify its address.                                                            
+WAP_EXPORT wap_client_t *
+    wap_client_new (const char *endpoint, int timeout, const char *address);
+
+//  Destroy the wap_client
+WAP_EXPORT void
+    wap_client_destroy (wap_client_t **self_p);
+
+//  Enable verbose logging of client activity
+WAP_EXPORT void
+    wap_client_verbose (wap_client_t *self);
+
+//  Return actor, when caller wants to work with multiple actors and/or
+//  input sockets asynchronously.
+WAP_EXPORT zactor_t *
+    wap_client_actor (wap_client_t *self);
+
+//  Return message pipe for asynchronous message I/O. In the high-volume case,
+//  we send methods and get replies to the actor, in a synchronous manner, and
+//  we send/recv high volume message data to a second pipe, the msgpipe. In
+//  the low-volume case we can do everything over the actor pipe, if traffic
+//  is never ambiguous.
+WAP_EXPORT zsock_t *
+    wap_client_msgpipe (wap_client_t *self);
+
+//  Request a set of blocks from the server.                                        
+//  Returns >= 0 if successful, -1 if interrupted.
+WAP_EXPORT int
+    wap_client_blocks (wap_client_t *self);
+
+//  Return last received status
+WAP_EXPORT int 
+    wap_client_status (wap_client_t *self);
+
+//  Return last received reason
+WAP_EXPORT const char *
+    wap_client_reason (wap_client_t *self);
+
+//  Return last received start_height
+WAP_EXPORT int 
+    wap_client_start_height (wap_client_t *self);
+
+//  Return last received curr_height
+WAP_EXPORT int 
+    wap_client_curr_height (wap_client_t *self);
+
+//  Return last received block_status
+WAP_EXPORT const char *
+    wap_client_block_status (wap_client_t *self);
+
+//  Return last received block_data
+WAP_EXPORT zmsg_t *
+    wap_client_block_data (wap_client_t *self);
+
+//  Self test of this class
+WAP_EXPORT void
+    wap_client_test (bool verbose);
+----
+
+DESCRIPTION
+-----------
+
+Description of class for man page.
+
+Detailed discussion of the class, if any.
+
+EXAMPLE
+-------
+.From wap_client_test method
+----
+zactor_t *client = zactor_new (wap_client, NULL);
+if (verbose)
+    zstr_send (client, "VERBOSE");
+zactor_destroy (&client);
+----

--- a/doc/wap_server.doc
+++ b/doc/wap_server.doc
@@ -1,0 +1,80 @@
+#### wap_server - wap_server
+
+Description of class for man page.
+
+Detailed discussion of the class, if any.
+
+This is the class interface:
+
+    //  To work with wap_server, use the CZMQ zactor API:
+    //
+    //  Create new wap_server instance, passing logging prefix:
+    //
+    //      zactor_t *wap_server = zactor_new (wap_server, "myname");
+    //  
+    //  Destroy wap_server instance
+    //
+    //      zactor_destroy (&wap_server);
+    //  
+    //  Enable verbose logging of commands and activity:
+    //
+    //      zstr_send (wap_server, "VERBOSE");
+    //
+    //  Bind wap_server to specified endpoint. TCP endpoints may specify
+    //  the port number as "*" to aquire an ephemeral port:
+    //
+    //      zstr_sendx (wap_server, "BIND", endpoint, NULL);
+    //
+    //  Return assigned port number, specifically when BIND was done using an
+    //  an ephemeral port:
+    //
+    //      zstr_sendx (wap_server, "PORT", NULL);
+    //      char *command, *port_str;
+    //      zstr_recvx (wap_server, &command, &port_str, NULL);
+    //      assert (streq (command, "PORT"));
+    //
+    //  Specify configuration file to load, overwriting any previous loaded
+    //  configuration file or options:
+    //
+    //      zstr_sendx (wap_server, "CONFIGURE", filename, NULL);
+    //
+    //  Set configuration path value:
+    //
+    //      zstr_sendx (wap_server, "SET", path, value, NULL);
+    //    
+    //  Send zmsg_t instance to wap_server:
+    //
+    //      zactor_send (wap_server, &msg);
+    //
+    //  Receive zmsg_t instance from wap_server:
+    //
+    //      zmsg_t *msg = zactor_recv (wap_server);
+    //
+    //  This is the wap_server constructor as a zactor_fn:
+    //
+    WAP_EXPORT void
+        wap_server (zsock_t *pipe, void *args);
+    
+    //  Self test of this class
+    WAP_EXPORT void
+        wap_server_test (bool verbose);
+
+This is the class self test code:
+
+    zactor_t *server = zactor_new (wap_server, "server");
+    if (verbose)
+        zstr_send (server, "VERBOSE");
+    zstr_sendx (server, "BIND", "ipc://@/wap_server", NULL);
+    
+    zsock_t *client = zsock_new (ZMQ_DEALER);
+    assert (client);
+    zsock_set_rcvtimeo (client, 2000);
+    zsock_connect (client, "ipc://@/wap_server");
+    
+    //  TODO: fill this out
+    wap_proto_t *request = wap_proto_new ();
+    wap_proto_destroy (&request);
+    
+    zsock_destroy (&client);
+    zactor_destroy (&server);
+

--- a/doc/wap_server.txt
+++ b/doc/wap_server.txt
@@ -1,0 +1,92 @@
+wap_server(3)
+=============
+
+NAME
+----
+wap_server - wap_server
+
+SYNOPSIS
+--------
+----
+//  To work with wap_server, use the CZMQ zactor API:
+//
+//  Create new wap_server instance, passing logging prefix:
+//
+//      zactor_t *wap_server = zactor_new (wap_server, "myname");
+//  
+//  Destroy wap_server instance
+//
+//      zactor_destroy (&wap_server);
+//  
+//  Enable verbose logging of commands and activity:
+//
+//      zstr_send (wap_server, "VERBOSE");
+//
+//  Bind wap_server to specified endpoint. TCP endpoints may specify
+//  the port number as "*" to aquire an ephemeral port:
+//
+//      zstr_sendx (wap_server, "BIND", endpoint, NULL);
+//
+//  Return assigned port number, specifically when BIND was done using an
+//  an ephemeral port:
+//
+//      zstr_sendx (wap_server, "PORT", NULL);
+//      char *command, *port_str;
+//      zstr_recvx (wap_server, &command, &port_str, NULL);
+//      assert (streq (command, "PORT"));
+//
+//  Specify configuration file to load, overwriting any previous loaded
+//  configuration file or options:
+//
+//      zstr_sendx (wap_server, "CONFIGURE", filename, NULL);
+//
+//  Set configuration path value:
+//
+//      zstr_sendx (wap_server, "SET", path, value, NULL);
+//    
+//  Send zmsg_t instance to wap_server:
+//
+//      zactor_send (wap_server, &msg);
+//
+//  Receive zmsg_t instance from wap_server:
+//
+//      zmsg_t *msg = zactor_recv (wap_server);
+//
+//  This is the wap_server constructor as a zactor_fn:
+//
+WAP_EXPORT void
+    wap_server (zsock_t *pipe, void *args);
+
+//  Self test of this class
+WAP_EXPORT void
+    wap_server_test (bool verbose);
+----
+
+DESCRIPTION
+-----------
+
+Description of class for man page.
+
+Detailed discussion of the class, if any.
+
+EXAMPLE
+-------
+.From wap_server_test method
+----
+zactor_t *server = zactor_new (wap_server, "server");
+if (verbose)
+    zstr_send (server, "VERBOSE");
+zstr_sendx (server, "BIND", "ipc://@/wap_server", NULL);
+
+zsock_t *client = zsock_new (ZMQ_DEALER);
+assert (client);
+zsock_set_rcvtimeo (client, 2000);
+zsock_connect (client, "ipc://@/wap_server");
+
+//  TODO: fill this out
+wap_proto_t *request = wap_proto_new ();
+wap_proto_destroy (&request);
+
+zsock_destroy (&client);
+zactor_destroy (&server);
+----

--- a/doc/wap_tutorial.txt
+++ b/doc/wap_tutorial.txt
@@ -1,0 +1,1 @@
+wap_tutorial(1)

--- a/include/wap_client.h
+++ b/include/wap_client.h
@@ -1,0 +1,88 @@
+/*  =========================================================================
+    wap_client - Wallet Client API
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: wap_client.xml, or
+     * The code generation script that built this file: zproto_client_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+#ifndef __WAP_CLIENT_H_INCLUDED__
+#define __WAP_CLIENT_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  Opaque class structure
+#ifndef WAP_CLIENT_T_DEFINED
+typedef struct _wap_client_t wap_client_t;
+#define WAP_CLIENT_T_DEFINED
+#endif
+
+//  @interface
+//  Create a new wap_client
+//  Connect to server endpoint, with specified timeout in msecs (zero means wait    
+//  forever). Constructor succeeds if connection is successful. The caller may      
+//  specify its address.                                                            
+WAP_EXPORT wap_client_t *
+    wap_client_new (const char *endpoint, int timeout, const char *identity);
+
+//  Destroy the wap_client
+WAP_EXPORT void
+    wap_client_destroy (wap_client_t **self_p);
+
+//  Enable verbose logging of client activity
+WAP_EXPORT void
+    wap_client_verbose (wap_client_t *self);
+
+//  Return actor, when caller wants to work with multiple actors and/or
+//  input sockets asynchronously.
+WAP_EXPORT zactor_t *
+    wap_client_actor (wap_client_t *self);
+
+//  Return message pipe for asynchronous message I/O. In the high-volume case,
+//  we send methods and get replies to the actor, in a synchronous manner, and
+//  we send/recv high volume message data to a second pipe, the msgpipe. In
+//  the low-volume case we can do everything over the actor pipe, if traffic
+//  is never ambiguous.
+WAP_EXPORT zsock_t *
+    wap_client_msgpipe (wap_client_t *self);
+
+//  Send start command to server.                                                   
+//  Returns >= 0 if successful, -1 if interrupted.
+WAP_EXPORT int
+    wap_client_start (wap_client_t *self);
+
+//  Send stop command to server.                                                    
+//  Returns >= 0 if successful, -1 if interrupted.
+WAP_EXPORT int
+    wap_client_stop (wap_client_t *self);
+
+//  Return last received status
+WAP_EXPORT int 
+    wap_client_status (wap_client_t *self);
+
+//  Return last received reason
+WAP_EXPORT const char *
+    wap_client_reason (wap_client_t *self);
+
+//  Self test of this class
+WAP_EXPORT void
+    wap_client_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/wap_library.h
+++ b/include/wap_library.h
@@ -44,10 +44,16 @@
 //  Opaque class structures to allow forward references
 typedef struct _wap_proto_t wap_proto_t;
 #define WAP_PROTO_T_DEFINED
+typedef struct _wap_server_t wap_server_t;
+#define WAP_SERVER_T_DEFINED
+typedef struct _wap_client_t wap_client_t;
+#define WAP_CLIENT_T_DEFINED
 
 
 //  Public API classes
 #include "wap_proto.h"
+#include "wap_server.h"
+#include "wap_client.h"
 
 #endif
 /*

--- a/include/wap_proto.h
+++ b/include/wap_proto.h
@@ -31,7 +31,7 @@
     OPEN_OK - Daemon accepts wallet open request.
 
     BLOCKS - Wallet requests a set of blocks from the daemon. Daemon replies with
-GET-OK, or ERROR if the request is invalid.
+BLOCKS-OK, or ERROR if the request is invalid.
         block_ids           strings     
 
     BLOCKS_OK - Daemon returns a set of blocks to the wallet.
@@ -73,11 +73,26 @@ Daemon will reply with CLOSE-OK or ERROR.
 
     CLOSE_OK - Daemon replies to a wallet connection close request.
 
+    PING - Wallet heartbeats an idle connection.
+
+    PING_OK - Daemon replies to a wallet ping request.
+
     ERROR - Daemon replies with failure status. Status codes tbd.
         status              number 2    Error status
         reason              string      Printable explanation
 */
 
+#define WAP_PROTO_SUCCESS                   200
+#define WAP_PROTO_NOT_DELIVERED             300
+#define WAP_PROTO_CONTENT_TOO_LARGE         301
+#define WAP_PROTO_TIMEOUT_EXPIRED           302
+#define WAP_PROTO_CONNECTION_REFUSED        303
+#define WAP_PROTO_RESOURCE_LOCKED           400
+#define WAP_PROTO_ACCESS_REFUSED            401
+#define WAP_PROTO_NOT_FOUND                 404
+#define WAP_PROTO_COMMAND_INVALID           500
+#define WAP_PROTO_NOT_IMPLEMENTED           501
+#define WAP_PROTO_INTERNAL_ERROR            502
 
 #define WAP_PROTO_OPEN                      1
 #define WAP_PROTO_OPEN_OK                   2
@@ -95,7 +110,9 @@ Daemon will reply with CLOSE-OK or ERROR.
 #define WAP_PROTO_STOP_OK                   14
 #define WAP_PROTO_CLOSE                     15
 #define WAP_PROTO_CLOSE_OK                  16
-#define WAP_PROTO_ERROR                     17
+#define WAP_PROTO_PING                      17
+#define WAP_PROTO_PING_OK                   18
+#define WAP_PROTO_ERROR                     19
 
 #include <czmq.h>
 

--- a/include/wap_server.h
+++ b/include/wap_server.h
@@ -1,0 +1,85 @@
+/*  =========================================================================
+    wap_server - Wallet Server
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: wap_server.xml, or
+     * The code generation script that built this file: zproto_server_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+#ifndef __WAP_SERVER_H_INCLUDED__
+#define __WAP_SERVER_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  @interface
+//  To work with wap_server, use the CZMQ zactor API:
+//
+//  Create new wap_server instance, passing logging prefix:
+//
+//      zactor_t *wap_server = zactor_new (wap_server, "myname");
+//  
+//  Destroy wap_server instance
+//
+//      zactor_destroy (&wap_server);
+//  
+//  Enable verbose logging of commands and activity:
+//
+//      zstr_send (wap_server, "VERBOSE");
+//
+//  Bind wap_server to specified endpoint. TCP endpoints may specify
+//  the port number as "*" to aquire an ephemeral port:
+//
+//      zstr_sendx (wap_server, "BIND", endpoint, NULL);
+//
+//  Return assigned port number, specifically when BIND was done using an
+//  an ephemeral port:
+//
+//      zstr_sendx (wap_server, "PORT", NULL);
+//      char *command, *port_str;
+//      zstr_recvx (wap_server, &command, &port_str, NULL);
+//      assert (streq (command, "PORT"));
+//
+//  Specify configuration file to load, overwriting any previous loaded
+//  configuration file or options:
+//
+//      zstr_sendx (wap_server, "CONFIGURE", filename, NULL);
+//
+//  Set configuration path value:
+//
+//      zstr_sendx (wap_server, "SET", path, value, NULL);
+//    
+//  Send zmsg_t instance to wap_server:
+//
+//      zactor_send (wap_server, &msg);
+//
+//  Receive zmsg_t instance from wap_server:
+//
+//      zmsg_t *msg = zactor_recv (wap_server);
+//
+//  This is the wap_server constructor as a zactor_fn:
+//
+WAP_EXPORT void
+    wap_server (zsock_t *pipe, void *args);
+
+//  Self test of this class
+WAP_EXPORT void
+    wap_server_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/project.xml
+++ b/project.xml
@@ -8,7 +8,17 @@
     <include filename = "license.xml" />
     <version major = "0" minor = "0" patch = "1" />
     <use project = "czmq" />
-
+    
+    <main name = "wap_tutorial" private = "1" />
+    
     <class name = "wap_proto">Wallet Access Protocol</class>
+    <class name = "wap_server">Wallet server implementation</class>
+    <class name = "wap_client">Wallet client API</class>
+    
     <model name = "wap_proto" />
+    <model name = "wap_client" />
+    <model name = "wap_server" />
+    
+    <extra name = "wap_server_engine.inc" />
+    <extra name = "wap_client_engine.inc" />
 </project>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -13,10 +13,16 @@ pkgconfig_DATA = src/libwap.pc
 include_HEADERS = \
     include/wallet.h \
     include/wap_proto.h \
+    include/wap_server.h \
+    include/wap_client.h \
     include/wap_library.h
 
 src_libwap_la_SOURCES = \
     src/wap_proto.c \
+    src/wap_server.c \
+    src/wap_client.c \
+    src/wap_server_engine.inc \
+    src/wap_client_engine.inc \
     src/platform.h
 
 src_libwap_la_CPPFLAGS = ${AM_CPPFLAGS}
@@ -33,6 +39,11 @@ endif
 
 src_libwap_la_LIBADD = ${project_libs}
 
+bin_PROGRAMS += src/wap_tutorial
+src_wap_tutorial_CPPFLAGS = ${AM_CPPFLAGS}
+src_wap_tutorial_LDADD = ${program_libs}
+src_wap_tutorial_SOURCES = src/wap_tutorial.c
+
 check_PROGRAMS += src/wap_selftest
 src_wap_selftest_CPPFLAGS = ${src_libwap_la_CFLAGS}
 src_wap_selftest_LDADD = ${program_libs}
@@ -47,6 +58,8 @@ src: src/libwap.la src/wap_selftest
 # Produce generated code from models in the src directory
 code:
 	cd $(srcdir)/src; gsl -q wap_proto.xml
+	cd $(srcdir)/src; gsl -q wap_client.xml
+	cd $(srcdir)/src; gsl -q wap_server.xml
 
 # Run the selftest binary under valgrind to check for memory leaks
 memcheck: src/wap_selftest

--- a/src/wap_client.c
+++ b/src/wap_client.c
@@ -1,0 +1,214 @@
+/*  =========================================================================
+    wap_client - Wallet Client API
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+/*
+@header
+    Description of class for man page.
+@discuss
+    Detailed discussion of the class, if any.
+@end
+*/
+
+#include "wap_classes.h"
+//  TODO: Change these to match your project's needs
+#include "../include/wap_proto.h"
+#include "../include/wap_client.h"
+
+//  Forward reference to method arguments structure
+typedef struct _client_args_t client_args_t;
+
+//  This structure defines the context for a client connection
+typedef struct {
+    //  These properties must always be present in the client_t
+    //  and are set by the generated engine. The cmdpipe gets
+    //  messages sent to the actor; the msgpipe may be used for
+    //  faster asynchronous message flows.
+    zsock_t *cmdpipe;           //  Command pipe to/from caller API
+    zsock_t *msgpipe;           //  Message pipe to/from caller API
+    zsock_t *dealer;            //  Socket to talk to server
+    wap_proto_t *message;       //  Message to/from server
+    client_args_t *args;        //  Arguments from methods
+    
+    //  Own properties
+    int heartbeat_timer;        //  Timeout for heartbeats to server
+} client_t;
+
+//  Include the generated client engine
+#include "wap_client_engine.inc"
+
+//  Allocate properties and structures for a new client instance.
+//  Return 0 if OK, -1 if failed
+
+static int
+client_initialize (client_t *self)
+{
+    //  We'll ping the server once per second
+    self->heartbeat_timer = 1000;
+    return 0;
+}
+
+//  Free properties and structures for a client instance
+
+static void
+client_terminate (client_t *self)
+{
+    //  Destroy properties here
+}
+
+
+//  ---------------------------------------------------------------------------
+//  connect_to_server_endpoint
+//
+
+static void
+connect_to_server_endpoint (client_t *self)
+{
+    if (zsock_connect (self->dealer, "%s", self->args->endpoint)) {
+        engine_set_exception (self, bad_endpoint_event);
+        zsys_warning ("could not connect to %s", self->args->endpoint);
+    }
+}
+
+
+//  ---------------------------------------------------------------------------
+//  set_client_identity
+//
+
+static void
+set_client_identity (client_t *self)
+{
+    wap_proto_set_identity (self->message, self->args->identity);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  use_connect_timeout
+//
+
+static void
+use_connect_timeout (client_t *self)
+{
+    engine_set_timeout (self, self->args->timeout);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  use_heartbeat_timer
+//
+
+static void
+use_heartbeat_timer (client_t *self)
+{
+    engine_set_timeout (self, self->heartbeat_timer);
+}
+
+
+
+//  ---------------------------------------------------------------------------
+//  signal_success
+//
+
+static void
+signal_success (client_t *self)
+{
+    zsock_send (self->cmdpipe, "si", "SUCCESS", 0);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  signal_bad_endpoint
+//
+
+static void
+signal_bad_endpoint (client_t *self)
+{
+    zsock_send (self->cmdpipe, "sis", "FAILURE", -1, "Bad server endpoint");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  signal_failure
+//
+
+static void
+signal_failure (client_t *self)
+{
+    zsock_send (self->cmdpipe, "sis", "FAILURE", -1, wap_proto_reason (self->message));
+}
+
+
+//  ---------------------------------------------------------------------------
+//  check_status_code
+//
+
+static void
+check_status_code (client_t *self)
+{
+    if (wap_proto_status (self->message) == WAP_PROTO_COMMAND_INVALID)
+        engine_set_next_event (self, command_invalid_event);
+    else
+        engine_set_next_event (self, other_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  signal_unhandled_error
+//
+
+static void
+signal_unhandled_error (client_t *self)
+{
+    zsys_error ("unhandled error code from server");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  signal_server_not_present
+//
+
+static void
+signal_server_not_present (client_t *self)
+{
+    zsock_send (self->cmdpipe, "sis", "FAILURE", -1, "Server is not reachable");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Selftest
+
+void
+wap_client_test (bool verbose)
+{
+    printf (" * wap_client: ");
+    if (verbose)
+        printf ("\n");
+
+    //  @selftest
+    //  Start a server to test against, and bind to endpoint
+    zactor_t *server = zactor_new (wap_server, "wap_client_test");
+    if (verbose)
+        zstr_send (server, "VERBOSE");
+    zsock_send (server, "ss", "BIND", "ipc://@/monero");
+
+    wap_client_t *client = wap_client_new ("ipc://@/monero", 1000, "test client");
+    assert (client);
+    if (verbose)
+        wap_client_verbose (client);
+
+    int rc = wap_client_start (client);
+    assert (rc == 0);
+    rc = wap_client_stop (client);
+    assert (rc == 0);
+    
+    wap_client_destroy (&client);
+    
+    zactor_destroy (&server);
+    //  @end
+    printf ("OK\n");
+}

--- a/src/wap_client.xml
+++ b/src/wap_client.xml
@@ -1,0 +1,198 @@
+<class
+    name = "wap_client"
+    title = "Wallet Client API"
+    script = "zproto_client_c"
+    protocol_class = "wap_proto"
+    package_dir = "../include"
+    project_header = "wap_classes.h"
+    export_macro = "WAP_EXPORT"
+    >
+    This is a client implementation of the Wallet Access Protocol
+    <include filename = "../license.xml" />
+
+    <state name = "start">
+        <event name = "constructor" next = "expect open ok">
+            <action name = "connect to server endpoint" />
+            <action name = "set client identity" />
+            <action name = "use connect timeout" />
+            <action name = "send" message = "OPEN" />
+        </event>
+        <event name = "bad endpoint">
+            <action name = "signal bad endpoint" />
+            <action name = "terminate" />
+        </event>
+    </state>
+
+    <state name = "expect open ok" inherit = "defaults">
+        <event name = "OPEN OK" next = "connected">
+            <action name = "signal success" />
+            <action name = "use heartbeat timer" />
+        </event>
+        <event name = "expired">
+            <action name = "signal server not present" />
+            <action name = "terminate" />
+        </event>
+    </state>
+    
+    <state name = "connected" inherit = "defaults">
+        <!--
+        <event name = "blocks" next = "expect blocks ok">
+            <action name = "prepare blocks command" />
+            <action name = "send" message = "BLOCKS" />
+        </event>
+        <event name = "get" next = "expect get ok">
+            <action name = "prepare get command" />
+            <action name = "send" message = "GET" />
+        </event>
+        <event name = "put" next = "expect put ok">
+            <action name = "prepare put command" />
+            <action name = "send" message = "PUT" />
+        </event>
+        <event name = "save" next = "expect save ok">
+            <action name = "prepare save command" />
+            <action name = "send" message = "SAVE" />
+        </event>
+        -->
+        <event name = "start" next = "expect start ok">
+            <action name = "send" message = "START" />
+        </event>
+        <event name = "stop" next = "expect stop ok">
+            <action name = "send" message = "STOP" />
+        </event>
+        <event name = "destructor" next = "expect close ok">
+            <action name = "send" message = "CLOSE" />
+        </event>
+        <event name = "expired">
+            <action name = "send" message = "PING" />
+        </event>
+    </state>
+
+    <state name = "expect blocks ok" inherit = "defaults">
+        <event name = "BLOCKS OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect get ok" inherit = "defaults">
+        <event name = "GET OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect put ok" inherit = "defaults">
+        <event name = "PUT OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect save ok" inherit = "defaults">
+        <event name = "SAVE OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect start ok" inherit = "defaults">
+        <event name = "START OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect stop ok" inherit = "defaults">
+        <event name = "STOP OK" next = "connected">
+            <action name = "signal success" />
+        </event>
+    </state>
+
+    <state name = "expect close ok" inherit = "defaults">
+        <event name = "CLOSE OK">
+            <action name = "signal success" />
+            <action name = "terminate" />
+        </event>
+        <event name = "expired">
+            <action name = "signal failure" />
+            <action name = "terminate" />
+        </event>
+    </state>
+
+    <state name = "defaults">
+        <event name = "CONNECTION PONG">
+        </event>
+        <event name = "ERROR" next = "have error">
+            <action name = "check status code" />
+        </event>
+        <event name = "*">
+            <!-- Discard any other incoming events -->
+        </event>
+    </state>
+
+    <state name = "have error">
+        <event name = "command invalid" next = "reexpect open ok">
+            <action name = "use connect timeout" />
+            <action name = "send" message = "OPEN" />
+        </event>
+        <event name = "other">
+            <action name = "signal unhandled error" />
+            <action name = "terminate" />
+        </event>
+    </state>
+   
+    <state name = "reexpect open ok" inherit = "defaults">
+        <event name = "OPEN OK" next = "connected">
+            <action name = "use heartbeat timer" />
+        </event>
+    </state>
+
+    <!-- API methods -->
+    <method name = "constructor" return = "status">
+    Connect to server endpoint, with specified timeout in msecs (zero means
+    wait forever). Constructor succeeds if connection is successful. The caller
+    may specify its address.
+        <field name = "endpoint" type = "string" />
+        <field name = "timeout" type = "number" size = "4" />
+        <field name = "identity" type = "string" />
+        <accept reply = "SUCCESS" />
+        <accept reply = "FAILURE" />
+    </method>
+
+    <reply name = "SUCCESS">
+        <field name = "status" type = "number" size = "1" />
+    </reply>
+
+    <reply name = "FAILURE">
+        <field name = "status" type = "number" size = "1" />
+        <field name = "reason" type = "string" />
+    </reply>
+
+    <method name = "destructor" return = "status">
+    Disconnect from server. Waits for a short timeout for confirmation from
+    the server, then disconnects anyhow.
+        <accept reply = "SUCCESS" />
+        <accept reply = "FAILURE" />
+    </method>
+    
+    <method name = "start" return = "status">
+    Send start command to server.
+        <accept reply = "SUCCESS" />
+        <accept reply = "FAILURE" />
+    </method>
+
+    <method name = "stop" return = "status">
+    Send stop command to server.
+        <accept reply = "SUCCESS" />
+        <accept reply = "FAILURE" />
+    </method>
+
+<!--    <method name = "blocks" return = "status">
+    Request a set of blocks from the server.
+        <field name = "block ids" type = "list" />
+        <accept reply = "BLOCKS OK" />
+        <accept reply = "FAILURE" />
+    </method>
+
+    <reply name = "BLOCKS OK">
+        <field name = "start height" type = "number" />
+        <field name = "curr height" type = "number" />
+        <field name = "block status" type = "string" />
+        <field name = "block data" type = "msg" />
+    </reply>-->
+</class>

--- a/src/wap_client_engine.inc
+++ b/src/wap_client_engine.inc
@@ -1,0 +1,1282 @@
+/*  =========================================================================
+    wap_client_engine - Wallet Client API engine
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: wap_client.xml, or
+     * The code generation script that built this file: zproto_client_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+
+//  ---------------------------------------------------------------------------
+//  State machine constants
+
+typedef enum {
+    start_state = 1,
+    expect_open_ok_state = 2,
+    connected_state = 3,
+    expect_blocks_ok_state = 4,
+    expect_get_ok_state = 5,
+    expect_put_ok_state = 6,
+    expect_save_ok_state = 7,
+    expect_start_ok_state = 8,
+    expect_stop_ok_state = 9,
+    expect_close_ok_state = 10,
+    defaults_state = 11,
+    have_error_state = 12,
+    reexpect_open_ok_state = 13
+} state_t;
+
+typedef enum {
+    NULL_event = 0,
+    constructor_event = 1,
+    bad_endpoint_event = 2,
+    open_ok_event = 3,
+    expired_event = 4,
+    start_event = 5,
+    stop_event = 6,
+    destructor_event = 7,
+    blocks_ok_event = 8,
+    get_ok_event = 9,
+    put_ok_event = 10,
+    save_ok_event = 11,
+    start_ok_event = 12,
+    stop_ok_event = 13,
+    close_ok_event = 14,
+    connection_pong_event = 15,
+    error_event = 16,
+    command_invalid_event = 17,
+    other_event = 18
+} event_t;
+
+//  Names for state machine logging and error reporting
+static char *
+s_state_name [] = {
+    "(NONE)",
+    "start",
+    "expect open ok",
+    "connected",
+    "expect blocks ok",
+    "expect get ok",
+    "expect put ok",
+    "expect save ok",
+    "expect start ok",
+    "expect stop ok",
+    "expect close ok",
+    "defaults",
+    "have error",
+    "reexpect open ok"
+};
+
+static char *
+s_event_name [] = {
+    "(NONE)",
+    "constructor",
+    "bad_endpoint",
+    "OPEN_OK",
+    "expired",
+    "START",
+    "STOP",
+    "destructor",
+    "BLOCKS_OK",
+    "GET_OK",
+    "PUT_OK",
+    "SAVE_OK",
+    "START_OK",
+    "STOP_OK",
+    "CLOSE_OK",
+    "connection_pong",
+    "ERROR",
+    "command_invalid",
+    "other"
+};
+ 
+
+//  ---------------------------------------------------------------------------
+//  Context for the client. This embeds the application-level client context
+//  at its start (the entire structure, not a reference), so we can cast a
+//  pointer between client_t and s_client_t arbitrarily.
+
+//  These are the different method arguments we manage automatically
+struct _client_args_t {
+    char *endpoint;
+    int timeout;
+    char *identity;
+};
+
+typedef struct {
+    client_t client;            //  Application-level client context
+    zsock_t *cmdpipe;           //  Get/send commands from caller API
+    zsock_t *msgpipe;           //  Get/send messages from caller API
+    zsock_t *dealer;            //  Socket to talk to server
+    zloop_t *loop;              //  Listen to pipe and dealer
+    wap_proto_t *message;       //  Message received or sent
+    client_args_t args;         //  Method arguments structure
+    bool terminated;            //  True if client is shutdown
+    size_t timeout;             //  inactivity timeout, msecs
+    state_t state;              //  Current state
+    event_t event;              //  Current event
+    event_t next_event;         //  The next event
+    event_t exception;          //  Exception event, if any
+    int expiry_timer;           //  zloop timer for timeouts
+    int wakeup_timer;           //  zloop timer for alarms
+    event_t wakeup_event;       //  Wake up with this event
+    bool verbose;               //  Verbose logging enabled?
+} s_client_t;
+
+static int
+    client_initialize (client_t *self);
+static void
+    client_terminate (client_t *self);
+static void
+    s_client_destroy (s_client_t **self_p);
+static void
+    s_client_execute (s_client_t *self, event_t event);
+static int
+    s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
+static int
+    s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument);
+static void
+    s_satisfy_pedantic_compilers (void);
+static void
+    connect_to_server_endpoint (client_t *self);
+static void
+    set_client_identity (client_t *self);
+static void
+    use_connect_timeout (client_t *self);
+static void
+    signal_bad_endpoint (client_t *self);
+static void
+    signal_success (client_t *self);
+static void
+    use_heartbeat_timer (client_t *self);
+static void
+    signal_server_not_present (client_t *self);
+static void
+    signal_failure (client_t *self);
+static void
+    check_status_code (client_t *self);
+static void
+    signal_unhandled_error (client_t *self);
+
+//  Create a new client connection
+
+static s_client_t *
+s_client_new (zsock_t *cmdpipe, zsock_t *msgpipe)
+{
+    s_client_t *self = (s_client_t *) zmalloc (sizeof (s_client_t));
+    if (self) {
+        assert ((s_client_t *) &self->client == self);
+        self->cmdpipe = cmdpipe;
+        self->msgpipe = msgpipe;
+        self->dealer = zsock_new (ZMQ_DEALER);
+        if (self->dealer)
+            self->message = wap_proto_new ();
+        if (self->message)
+            self->loop = zloop_new ();
+        if (self->loop) {
+            //  Give application chance to initialize and set next event
+            self->state = start_state;
+            self->event = NULL_event;
+            self->client.cmdpipe = self->cmdpipe;
+            self->client.msgpipe = self->msgpipe;
+            self->client.dealer = self->dealer;
+            self->client.message = self->message;
+            self->client.args = &self->args;
+            if (client_initialize (&self->client))
+                s_client_destroy (&self);
+        }
+        else
+            s_client_destroy (&self);
+    }
+    s_satisfy_pedantic_compilers ();
+    return self;
+}
+
+//  Destroy the client connection
+
+static void
+s_client_destroy (s_client_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        s_client_t *self = *self_p;
+        zstr_free (&self->args.endpoint);
+        zstr_free (&self->args.identity);
+        client_terminate (&self->client);
+        wap_proto_destroy (&self->message);
+        zsock_destroy (&self->msgpipe);
+        zsock_destroy (&self->dealer);
+        zloop_destroy (&self->loop);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  ---------------------------------------------------------------------------
+//  These methods are an internal API for actions
+
+//  Set the next event, needed in at least one action in an internal
+//  state; otherwise the state machine will wait for a message on the
+//  dealer socket and treat that as the event.
+
+static void
+engine_set_next_event (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->next_event = event;
+    }
+}
+
+//  Raise an exception with 'event', halting any actions in progress.
+//  Continues execution of actions defined for the exception event.
+
+static void
+engine_set_exception (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->exception = event;
+    }
+}
+
+//  Set wakeup alarm after 'delay' msecs. The next state should handle the
+//  wakeup event. The alarm is cancelled on any other event.
+
+static void
+engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        if (self->wakeup_timer) {
+            zloop_timer_end (self->loop, self->wakeup_timer);
+            self->wakeup_timer = 0;
+        }
+        self->wakeup_timer = zloop_timer (
+            self->loop, delay, 1, s_client_handle_wakeup, self);
+        self->wakeup_event = event;
+    }
+}
+
+//  Set timeout for next protocol read. By default, will wait forever
+//  or until the process is interrupted. The timeout is in milliseconds.
+//  The state machine must handle the "expired" event.
+
+static void
+engine_set_timeout (client_t *client, size_t timeout)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->timeout = timeout;
+        if (self->timeout)
+            self->expiry_timer = zloop_timer (
+                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+    }
+}
+
+//  Poll socket for activity, invoke handler on any received message.
+//  Handler must be a CZMQ zloop_fn function; receives client as arg.
+
+static void
+engine_handle_socket (client_t *client, zsock_t *sock, zloop_reader_fn handler)
+{
+    if (client && sock) {
+        s_client_t *self = (s_client_t *) client;
+        if (handler != NULL) {
+            int rc = zloop_reader (self->loop, sock, handler, self);
+            assert (rc == 0);
+            zloop_reader_set_tolerant (self->loop, sock);
+        }
+        else
+            zloop_reader_end (self->loop, sock);
+    }
+}
+
+//  Pedantic compilers don't like unused functions, so we call the whole
+//  API, passing null references. It's nasty and horrid and sufficient.
+
+static void
+s_satisfy_pedantic_compilers (void)
+{
+    engine_set_next_event (NULL, NULL_event);
+    engine_set_exception (NULL, NULL_event);
+    engine_set_timeout (NULL, 0);
+    engine_set_wakeup_event (NULL, 0, NULL_event);
+    engine_handle_socket (NULL, 0, NULL);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Generic methods on protocol messages
+//  TODO: replace with lookup table, since ID is one byte
+
+static event_t
+s_protocol_event (s_client_t *self, wap_proto_t *message)
+{
+    assert (message);
+    switch (wap_proto_id (message)) {
+        case WAP_PROTO_OPEN_OK:
+            return open_ok_event;
+            break;
+        case WAP_PROTO_BLOCKS_OK:
+            return blocks_ok_event;
+            break;
+        case WAP_PROTO_PUT_OK:
+            return put_ok_event;
+            break;
+        case WAP_PROTO_GET_OK:
+            return get_ok_event;
+            break;
+        case WAP_PROTO_SAVE_OK:
+            return save_ok_event;
+            break;
+        case WAP_PROTO_START:
+            return start_event;
+            break;
+        case WAP_PROTO_START_OK:
+            return start_ok_event;
+            break;
+        case WAP_PROTO_STOP:
+            return stop_event;
+            break;
+        case WAP_PROTO_STOP_OK:
+            return stop_ok_event;
+            break;
+        case WAP_PROTO_CLOSE_OK:
+            return close_ok_event;
+            break;
+        case WAP_PROTO_ERROR:
+            return error_event;
+            break;
+        default:
+            zsys_error ("wap_client: unknown command %s, halting", wap_proto_command (message));
+            self->terminated = true;
+            return NULL_event;
+    }
+}
+
+
+//  Execute state machine as long as we have events; if event is NULL_event,
+//  or state machine is terminated, do nothing.
+
+static void
+s_client_execute (s_client_t *self, event_t event)
+{
+    self->next_event = event;
+    //  Cancel wakeup timer, if any was pending
+    if (self->wakeup_timer) {
+        zloop_timer_end (self->loop, self->wakeup_timer);
+        self->wakeup_timer = 0;
+    }
+    while (!self->terminated && self->next_event != NULL_event) {
+        self->event = self->next_event;
+        self->next_event = NULL_event;
+        self->exception = NULL_event;
+        if (self->verbose) {
+            zsys_debug ("wap_client: %s:", s_state_name [self->state]);
+            zsys_debug ("wap_client:        %s", s_event_name [self->event]);
+        }
+        switch (self->state) {
+            case start_state:
+                if (self->event == constructor_event) {
+                    if (!self->exception) {
+                        //  connect to server endpoint
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ connect to server endpoint");
+                        connect_to_server_endpoint (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  set client identity
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ set client identity");
+                        set_client_identity (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  use connect timeout
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ use connect timeout");
+                        use_connect_timeout (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OPEN
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send OPEN");
+                        wap_proto_set_id (self->message, WAP_PROTO_OPEN);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                    if (!self->exception)
+                        self->state = expect_open_ok_state;
+                }
+                else
+                if (self->event == bad_endpoint_event) {
+                    if (!self->exception) {
+                        //  signal bad endpoint
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal bad endpoint");
+                        signal_bad_endpoint (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ terminate");
+                        self->terminated = true;
+                    }
+                }
+                else {
+                    //  Handle unexpected internal events
+                    zsys_warning ("wap_client: unhandled event %s in %s",
+                        s_event_name [self->event], s_state_name [self->state]);
+                    assert (false);
+                }
+                break;
+
+            case expect_open_ok_state:
+                if (self->event == open_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  use heartbeat timer
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ use heartbeat timer");
+                        use_heartbeat_timer (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  signal server not present
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal server not present");
+                        signal_server_not_present (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ terminate");
+                        self->terminated = true;
+                    }
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case connected_state:
+                if (self->event == start_event) {
+                    if (!self->exception) {
+                        //  send START
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send START");
+                        wap_proto_set_id (self->message, WAP_PROTO_START);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                    if (!self->exception)
+                        self->state = expect_start_ok_state;
+                }
+                else
+                if (self->event == stop_event) {
+                    if (!self->exception) {
+                        //  send STOP
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send STOP");
+                        wap_proto_set_id (self->message, WAP_PROTO_STOP);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                    if (!self->exception)
+                        self->state = expect_stop_ok_state;
+                }
+                else
+                if (self->event == destructor_event) {
+                    if (!self->exception) {
+                        //  send CLOSE
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send CLOSE");
+                        wap_proto_set_id (self->message, WAP_PROTO_CLOSE);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                    if (!self->exception)
+                        self->state = expect_close_ok_state;
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  send PING
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send PING");
+                        wap_proto_set_id (self->message, WAP_PROTO_PING);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_blocks_ok_state:
+                if (self->event == blocks_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_get_ok_state:
+                if (self->event == get_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_put_ok_state:
+                if (self->event == put_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_save_ok_state:
+                if (self->event == save_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_start_ok_state:
+                if (self->event == start_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_stop_ok_state:
+                if (self->event == stop_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case expect_close_ok_state:
+                if (self->event == close_ok_event) {
+                    if (!self->exception) {
+                        //  signal success
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal success");
+                        signal_success (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ terminate");
+                        self->terminated = true;
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  signal failure
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal failure");
+                        signal_failure (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ terminate");
+                        self->terminated = true;
+                    }
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case defaults_state:
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case have_error_state:
+                if (self->event == command_invalid_event) {
+                    if (!self->exception) {
+                        //  use connect timeout
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ use connect timeout");
+                        use_connect_timeout (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OPEN
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ send OPEN");
+                        wap_proto_set_id (self->message, WAP_PROTO_OPEN);
+                        wap_proto_send (self->message, self->dealer);
+                    }
+                    if (!self->exception)
+                        self->state = reexpect_open_ok_state;
+                }
+                else
+                if (self->event == other_event) {
+                    if (!self->exception) {
+                        //  signal unhandled error
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ signal unhandled error");
+                        signal_unhandled_error (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ terminate");
+                        self->terminated = true;
+                    }
+                }
+                else {
+                    //  Handle unexpected internal events
+                    zsys_warning ("wap_client: unhandled event %s in %s",
+                        s_event_name [self->event], s_state_name [self->state]);
+                    assert (false);
+                }
+                break;
+
+            case reexpect_open_ok_state:
+                if (self->event == open_ok_event) {
+                    if (!self->exception) {
+                        //  use heartbeat timer
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ use heartbeat timer");
+                        use_heartbeat_timer (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
+                }
+                else
+                if (self->event == error_event) {
+                    if (!self->exception) {
+                        //  check status code
+                        if (self->verbose)
+                            zsys_debug ("wap_client:            $ check status code");
+                        check_status_code (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = have_error_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+        }
+        //  If we had an exception event, interrupt normal programming
+        if (self->exception) {
+            if (self->verbose)
+                zsys_debug ("wap_client:            ! %s", s_event_name [self->exception]);
+            self->next_event = self->exception;
+        }
+        else
+        if (self->verbose)
+            zsys_debug ("wap_client:            > %s", s_state_name [self->state]);
+    }
+}
+
+//  zloop callback when client inactivity timer expires
+
+static int
+s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, expired_event);
+    return self->terminated? -1: 0;
+}
+
+//  zloop callback when client wakeup timer expires
+
+static int
+s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, self->wakeup_event);
+    return 0;
+}
+
+
+//  Handle command pipe to/from calling API
+
+static int
+s_client_handle_cmdpipe (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    char *method = zstr_recv (self->cmdpipe);
+    if (!method)
+        return -1;                  //  Interrupted; exit zloop
+    if (self->verbose)
+        zsys_debug ("wap_client:        API command=%s", method);
+
+    if (streq (method, "VERBOSE"))
+        self->verbose = true;       //  Start verbose logging
+    else
+    if (streq (method, "$TERM"))
+        self->terminated = true;    //  Shutdown the engine
+    else
+    if (streq (method, "CONSTRUCTOR")) {
+        zstr_free (&self->args.endpoint);
+        zstr_free (&self->args.identity);
+        zsock_recv (self->cmdpipe, "sis", &self->args.endpoint, &self->args.timeout, &self->args.identity);
+        s_client_execute (self, constructor_event);
+    }
+    else
+    if (streq (method, "DESTRUCTOR")) {
+        s_client_execute (self, destructor_event);
+    }
+    else
+    if (streq (method, "START")) {
+        s_client_execute (self, start_event);
+    }
+    else
+    if (streq (method, "STOP")) {
+        s_client_execute (self, stop_event);
+    }
+    //  Cleanup pipe if any argument frames are still waiting to be eaten
+    if (zsock_rcvmore (self->cmdpipe)) {
+        zsys_error ("wap_client: trailing API command frames (%s)", method);
+        zmsg_t *more = zmsg_recv (self->cmdpipe);
+        zmsg_print (more);
+        zmsg_destroy (&more);
+    }
+    zstr_free (&method);
+    return self->terminated? -1: 0;
+}
+
+
+//  Handle message pipe to/from calling API
+
+static int
+s_client_handle_msgpipe (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+
+    //  We will process as many messages as we can, to reduce the overhead
+    //  of polling and the reactor:
+    while (zsock_events (self->msgpipe) & ZMQ_POLLIN) {
+        char *method = zstr_recv (self->msgpipe);
+        if (!method)
+            return -1;              //  Interrupted; exit zloop
+        if (self->verbose)
+            zsys_debug ("wap_client:        API message=%s", method);
+
+        //  Front-end shuts down msgpipe before cmdpipe
+        if (streq (method, "$TERM"))
+            zsock_signal (self->cmdpipe, 0);
+        //  Cleanup pipe if any argument frames are still waiting to be eaten
+        if (zsock_rcvmore (self->msgpipe)) {
+            zsys_error ("wap_client: trailing API message frames (%s)", method);
+            zmsg_t *more = zmsg_recv (self->msgpipe);
+            zmsg_print (more);
+            zmsg_destroy (&more);
+        }
+        zstr_free (&method);
+    }
+    return 0;
+}
+
+
+//  Handle a message (a protocol reply) from the server
+
+static int
+s_client_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+
+    //  We will process as many messages as we can, to reduce the overhead
+    //  of polling and the reactor:
+    while (zsock_events (self->dealer) & ZMQ_POLLIN) {
+        if (wap_proto_recv (self->message, self->dealer))
+            return -1;              //  Interrupted; exit zloop
+
+        //  Any input from server counts as activity
+        if (self->expiry_timer) {
+            zloop_timer_end (self->loop, self->expiry_timer);
+            self->expiry_timer = 0;
+        }
+        //  Reset expiry timer if timeout is not zero
+        if (self->timeout)
+            self->expiry_timer = zloop_timer (
+                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+        s_client_execute (self, s_protocol_event (self, self->message));
+        if (self->terminated)
+            return -1;
+    }
+    return 0;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  This is the client actor, which polls its two sockets and processes
+//  incoming messages
+
+void
+wap_client (zsock_t *cmdpipe, void *msgpipe)
+{
+    //  Initialize
+    s_client_t *self = s_client_new (cmdpipe, (zsock_t *) msgpipe);
+    if (self) {
+        zsock_signal (cmdpipe, 0);
+        
+        //  Set up handler for the sockets the client uses
+        engine_handle_socket ((client_t *) self, self->cmdpipe, s_client_handle_cmdpipe);
+        engine_handle_socket ((client_t *) self, self->msgpipe, s_client_handle_msgpipe);
+        engine_handle_socket ((client_t *) self, self->dealer, s_client_handle_protocol);
+
+        //  Run reactor until there's a termination signal
+        zloop_start (self->loop);
+
+        //  Reactor has ended
+        s_client_destroy (&self);
+    }
+    else
+        zsock_signal (cmdpipe, -1);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Class interface
+
+struct _wap_client_t {
+    zactor_t *actor;            //  Client actor
+    zsock_t *msgpipe;           //  Pipe for async message flow
+    int status;                 //  Returned by actor reply
+    char *reason;               //  Returned by actor reply
+};
+
+
+//  ---------------------------------------------------------------------------
+//  Create a new wap_client
+//  Connect to server endpoint, with specified timeout in msecs (zero means wait    
+//  forever). Constructor succeeds if connection is successful. The caller may      
+//  specify its address.                                                            
+
+static int
+wap_client_constructor (wap_client_t *self, const char *endpoint, int timeout, const char *identity);
+
+WAP_EXPORT wap_client_t *
+wap_client_new (const char *endpoint, int timeout, const char *identity)
+{
+    wap_client_t *self = (wap_client_t *) zmalloc (sizeof (wap_client_t));
+    if (self) {
+        zsock_t *backend;
+        self->msgpipe = zsys_create_pipe (&backend);
+        self->actor = zactor_new (wap_client, backend);
+        if (self->actor)
+            self->status = wap_client_constructor (self, endpoint, timeout, identity);
+        if (self->status == -1)
+            zactor_destroy (&self->actor);
+        if (!self->actor)
+            wap_client_destroy (&self);
+    }
+    return self;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Destroy the wap_client
+//  Disconnect from server. Waits for a short timeout for confirmation from the     
+//  server, then disconnects anyhow.                                                
+
+static int
+wap_client_destructor (wap_client_t *self);
+
+void
+wap_client_destroy (wap_client_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        wap_client_t *self = *self_p;
+        if (self->actor && !zsys_interrupted) {
+            //  Shut down msgpipe first so that client can do clean shutdown,
+            //  sending any pending messages and handshaking goodbye to server
+            zstr_send (self->msgpipe, "$TERM");
+            zsock_wait (self->actor);
+            wap_client_destructor (self);
+        }
+        zactor_destroy (&self->actor);
+        zsock_destroy (&self->msgpipe);
+        zstr_free (&self->reason);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Enable verbose logging of client activity
+
+void
+wap_client_verbose (wap_client_t *self)
+{
+    assert (self);
+    zsock_send (self->actor, "s", "VERBOSE");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Return actor, when caller wants to work with multiple actors and/or
+//  input sockets asynchronously.
+
+zactor_t *
+wap_client_actor (wap_client_t *self)
+{
+    assert (self);
+    return self->actor;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Return message pipe for asynchronous message I/O. In the high-volume case,
+//  we send methods and get replies to the actor, in a synchronous manner, and
+//  we send/recv high volume message data to a second pipe, the msgpipe. In
+//  the low-volume case we can do everything over the actor pipe, if traffic
+//  is never ambiguous.
+
+zsock_t *
+wap_client_msgpipe (wap_client_t *self)
+{
+    assert (self);
+    return self->msgpipe;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Get valid reply from actor; discard replies that does not match. Current
+//  implementation filters on first frame of message. Blocks until a valid
+//  reply is received, and properties can be loaded from it. Returns 0 if
+//  matched, -1 if interrupted or timed-out.
+
+static int
+s_accept_reply (wap_client_t *self, ...)
+{
+    assert (self);
+    while (!zsys_interrupted) {
+        char *reply = zstr_recv (self->actor);
+        if (!reply)
+            break;              //  Interrupted or timed-out
+        
+        va_list args;
+        va_start (args, self);
+        char *filter = va_arg (args, char *);
+        while (filter) {
+            if (streq (reply, filter)) {
+                if (streq (reply, "SUCCESS")) {
+                    zsock_recv (self->actor, "i", &self->status);
+                }
+                else
+                if (streq (reply, "FAILURE")) {
+                    zstr_free (&self->reason);
+                    zsock_recv (self->actor, "is", &self->status, &self->reason);
+                }
+                break;
+            }
+            filter = va_arg (args, char *);
+        }
+        va_end (args);
+        //  If anything was remaining on pipe, flush it
+        zsock_flush (self->actor);
+        if (filter) {
+            zstr_free (&reply);
+            return 0;           //  We matched one of the filters
+        }
+    }
+    return -1;          //  Interrupted or timed-out
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Connect to server endpoint, with specified timeout in msecs (zero means wait    
+//  forever). Constructor succeeds if connection is successful. The caller may      
+//  specify its address.                                                            
+//  Returns >= 0 if successful, -1 if interrupted.
+
+static int
+wap_client_constructor (wap_client_t *self, const char *endpoint, int timeout, const char *identity)
+{
+    assert (self);
+    zsock_send (self->actor, "ssis", "CONSTRUCTOR", endpoint, timeout, identity);
+    if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
+        return -1;              //  Interrupted or timed-out
+    return self->status;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Disconnect from server. Waits for a short timeout for confirmation from the     
+//  server, then disconnects anyhow.                                                
+//  Returns >= 0 if successful, -1 if interrupted.
+
+int
+wap_client_destructor (wap_client_t *self)
+{
+    assert (self);
+    zsock_send (self->actor, "s", "DESTRUCTOR");
+    if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
+        return -1;              //  Interrupted or timed-out
+    return self->status;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Send start command to server.                                                   
+//  Returns >= 0 if successful, -1 if interrupted.
+
+int
+wap_client_start (wap_client_t *self)
+{
+    assert (self);
+    zsock_send (self->actor, "s", "START");
+    if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
+        return -1;              //  Interrupted or timed-out
+    return self->status;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Send stop command to server.                                                    
+//  Returns >= 0 if successful, -1 if interrupted.
+
+int
+wap_client_stop (wap_client_t *self)
+{
+    assert (self);
+    zsock_send (self->actor, "s", "STOP");
+    if (s_accept_reply (self, "SUCCESS", "FAILURE", NULL))
+        return -1;              //  Interrupted or timed-out
+    return self->status;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Return last received status
+
+int 
+wap_client_status (wap_client_t *self)
+{
+    assert (self);
+    return self->status;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Return last received reason
+
+const char *
+wap_client_reason (wap_client_t *self)
+{
+    assert (self);
+    return self->reason;
+}

--- a/src/wap_proto.bnf
+++ b/src/wap_proto.bnf
@@ -30,7 +30,7 @@ The following ABNF grammar defines the Wallet Access Protocol:
     OPEN-OK         = signature %d2
 
     ;  Wallet requests a set of blocks from the daemon. Daemon replies with  
-    ;  GET-OK, or ERROR if the request is invalid.                           
+    ;  BLOCKS-OK, or ERROR if the request is invalid.                        
 
     BLOCKS          = signature %d3 block ids
     block ids       = strings               ; 
@@ -100,9 +100,17 @@ The following ABNF grammar defines the Wallet Access Protocol:
 
     CLOSE-OK        = signature %d16
 
+    ;  Wallet heartbeats an idle connection.                                 
+
+    PING            = signature %d17
+
+    ;  Daemon replies to a wallet ping request.                              
+
+    PING-OK         = signature %d18
+
     ;  Daemon replies with failure status. Status codes tbd.                 
 
-    ERROR           = signature %d17 status reason
+    ERROR           = signature %d19 status reason
     status          = number-2              ; Error status
     reason          = string                ; Printable explanation
 

--- a/src/wap_proto.c
+++ b/src/wap_proto.c
@@ -379,6 +379,12 @@ wap_proto_recv (wap_proto_t *self, zsock_t *input)
         case WAP_PROTO_CLOSE_OK:
             break;
 
+        case WAP_PROTO_PING:
+            break;
+
+        case WAP_PROTO_PING_OK:
+            break;
+
         case WAP_PROTO_ERROR:
             GET_NUMBER2 (self->status);
             GET_STRING (self->reason);
@@ -657,6 +663,14 @@ wap_proto_print (wap_proto_t *self)
             zsys_debug ("WAP_PROTO_CLOSE_OK:");
             break;
             
+        case WAP_PROTO_PING:
+            zsys_debug ("WAP_PROTO_PING:");
+            break;
+            
+        case WAP_PROTO_PING_OK:
+            zsys_debug ("WAP_PROTO_PING_OK:");
+            break;
+            
         case WAP_PROTO_ERROR:
             zsys_debug ("WAP_PROTO_ERROR:");
             zsys_debug ("    status=%ld", (long) self->status);
@@ -760,6 +774,12 @@ wap_proto_command (wap_proto_t *self)
             break;
         case WAP_PROTO_CLOSE_OK:
             return ("CLOSE_OK");
+            break;
+        case WAP_PROTO_PING:
+            return ("PING");
+            break;
+        case WAP_PROTO_PING_OK:
+            return ("PING_OK");
             break;
         case WAP_PROTO_ERROR:
             return ("ERROR");
@@ -1220,6 +1240,26 @@ wap_proto_test (bool verbose)
         assert (wap_proto_routing_id (self));
     }
     wap_proto_set_id (self, WAP_PROTO_CLOSE_OK);
+
+    //  Send twice
+    wap_proto_send (self, output);
+    wap_proto_send (self, output);
+
+    for (instance = 0; instance < 2; instance++) {
+        wap_proto_recv (self, input);
+        assert (wap_proto_routing_id (self));
+    }
+    wap_proto_set_id (self, WAP_PROTO_PING);
+
+    //  Send twice
+    wap_proto_send (self, output);
+    wap_proto_send (self, output);
+
+    for (instance = 0; instance < 2; instance++) {
+        wap_proto_recv (self, input);
+        assert (wap_proto_routing_id (self));
+    }
+    wap_proto_set_id (self, WAP_PROTO_PING_OK);
 
     //  Send twice
     wap_proto_send (self, output);

--- a/src/wap_proto.xml
+++ b/src/wap_proto.xml
@@ -40,7 +40,7 @@
 
     <message name = "BLOCKS">
         Wallet requests a set of blocks from the daemon. Daemon replies with
-        GET-OK, or ERROR if the request is invalid.
+        BLOCKS-OK, or ERROR if the request is invalid.
         <field name = "block ids" type = "strings" />
     </message>
 
@@ -109,9 +109,36 @@
         Daemon replies to a wallet connection close request.
     </message>
 
+    <message name = "PING">
+        Wallet heartbeats an idle connection.
+    </message>
+
+    <message name = "PING-OK">
+        Daemon replies to a wallet ping request.
+    </message>
+
     <message name = "ERROR">
         Daemon replies with failure status. Status codes tbd.
         <field name = "status" type = "number" size = "2">Error status</field>
         <field name = "reason" type = "string">Printable explanation</field>
     </message>
+    
+    <!-- Success codes -->
+    <define name = "SUCCESS" value = "200" />
+
+    <!-- Temporary errors -->
+    <define name = "NOT DELIVERED" value = "300" />
+    <define name = "CONTENT TOO LARGE" value = "301" />
+    <define name = "TIMEOUT EXPIRED" value = "302" />
+    <define name = "CONNECTION REFUSED" value = "303" />
+
+    <!-- Application errors -->
+    <define name = "RESOURCE LOCKED" value = "400" />
+    <define name = "ACCESS REFUSED" value = "401" />
+    <define name = "NOT FOUND" value = "404" />
+
+    <!-- System errors -->
+    <define name = "COMMAND INVALID" value = "500" />
+    <define name = "NOT IMPLEMENTED" value = "501" />
+    <define name = "INTERNAL ERROR" value = "502" />
 </class>

--- a/src/wap_selftest.c
+++ b/src/wap_selftest.c
@@ -29,6 +29,8 @@ main (int argc, char *argv [])
     printf ("Running wallet selftests...\n");
 
     wap_proto_test (verbose); 
+    wap_server_test (verbose); 
+    wap_client_test (verbose); 
 
     printf ("Tests passed OK\n");
     return 0;

--- a/src/wap_server.c
+++ b/src/wap_server.c
@@ -1,0 +1,241 @@
+/*  =========================================================================
+    wap_server - wap_server
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+/*
+@header
+    Description of class for man page.
+@discuss
+    Detailed discussion of the class, if any.
+@end
+*/
+
+#include "wap_classes.h"
+//  TODO: Change these to match your project's needs
+#include "../include/wap_proto.h"
+#include "../include/wap_server.h"
+
+//  ---------------------------------------------------------------------------
+//  Forward declarations for the two main classes we use here
+
+typedef struct _server_t server_t;
+typedef struct _client_t client_t;
+
+//  This structure defines the context for each running server. Store
+//  whatever properties and structures you need for the server.
+
+struct _server_t {
+    //  These properties must always be present in the server_t
+    //  and are set by the generated engine; do not modify them!
+    zsock_t *pipe;              //  Actor pipe back to caller
+    zconfig_t *config;          //  Current loaded configuration
+    
+    //  TODO: Add any properties you need here
+};
+
+//  ---------------------------------------------------------------------------
+//  This structure defines the state for each client connection. It will
+//  be passed to each action in the 'self' argument.
+
+struct _client_t {
+    //  These properties must always be present in the client_t
+    //  and are set by the generated engine; do not modify them!
+    server_t *server;           //  Reference to parent server
+    wap_proto_t *message;       //  Message in and out
+
+    //  TODO: Add specific properties for your application
+};
+
+//  Include the generated server engine
+#include "wap_server_engine.inc"
+
+//  Allocate properties and structures for a new server instance.
+//  Return 0 if OK, or -1 if there was an error.
+
+static int
+server_initialize (server_t *self)
+{
+    //  Construct properties here
+    return 0;
+}
+
+//  Free properties and structures for a server instance
+
+static void
+server_terminate (server_t *self)
+{
+    //  Destroy properties here
+}
+
+//  Process server API method, return reply message if any
+
+static zmsg_t *
+server_method (server_t *self, const char *method, zmsg_t *msg)
+{
+    return NULL;
+}
+
+
+//  Allocate properties and structures for a new client connection and
+//  optionally engine_set_next_event (). Return 0 if OK, or -1 on error.
+
+static int
+client_initialize (client_t *self)
+{
+    //  Construct properties here
+    return 0;
+}
+
+//  Free properties and structures for a client connection
+
+static void
+client_terminate (client_t *self)
+{
+    //  Destroy properties here
+}
+
+//  ---------------------------------------------------------------------------
+//  Selftest
+
+void
+wap_server_test (bool verbose)
+{
+    printf (" * wap_server: ");
+    if (verbose)
+        printf ("\n");
+    
+    //  @selftest
+    zactor_t *server = zactor_new (wap_server, "server");
+    if (verbose)
+        zstr_send (server, "VERBOSE");
+    zstr_sendx (server, "BIND", "ipc://@/wap_server", NULL);
+
+    zsock_t *client = zsock_new (ZMQ_DEALER);
+    assert (client);
+    zsock_set_rcvtimeo (client, 2000);
+    zsock_connect (client, "ipc://@/wap_server");
+
+    //  TODO: fill this out
+    wap_proto_t *request = wap_proto_new ();
+    wap_proto_destroy (&request);
+    
+    zsock_destroy (&client);
+    zactor_destroy (&server);
+    //  @end
+    printf ("OK\n");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  register_the_wallet
+//
+
+static void
+register_the_wallet (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  message_not_valid_in_this_state
+//
+
+static void
+message_not_valid_in_this_state (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  retrieve_the_blocks
+//
+
+static void
+retrieve_the_blocks (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  store_the_transaction
+//
+
+static void
+store_the_transaction (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  retrieve_the_transaction
+//
+
+static void
+retrieve_the_transaction (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  start_the_mining_process
+//
+
+static void
+start_the_mining_process (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  stop_the_mining_process
+//
+
+static void
+stop_the_mining_process (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  deregister_the_wallet
+//
+
+static void
+deregister_the_wallet (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  allow_time_to_settle
+//
+
+static void
+allow_time_to_settle (client_t *self)
+{
+
+}
+
+
+//  ---------------------------------------------------------------------------
+//  register_new_client
+//
+
+static void
+register_new_client (client_t *self)
+{
+
+}

--- a/src/wap_server.xml
+++ b/src/wap_server.xml
@@ -1,0 +1,95 @@
+<class
+    name = "wap_server"
+    title = "Wallet Server"
+    script = "zproto_server_c"
+    protocol_class = "wap_proto"
+    package_dir = "../include"
+    project_header = "wap_classes.h"
+    export_macro = "WAP_EXPORT"
+    >
+    This is a server implementation of the Wallet Access Protocol
+    <include filename = "../license.xml" />
+
+    <state name = "start" inherit = "external">
+        <event name = "OPEN" next = "connected">
+            <action name = "register the wallet" />
+            <action name = "send" message = "OPEN OK" />
+        </event>
+        <!-- If wallet sends us anything after we restart, we signal error
+            and wallet will then close its connection, and reconnect -->
+        <event name = "*">
+            <action name = "message not valid in this state" />
+            <action name = "send" message = "ERROR" />
+        </event>
+    </state>
+
+    <state name = "connected" inherit = "external">
+        <event name = "BLOCKS">
+            <action name = "retrieve the blocks" />
+            <action name = "send" message = "BLOCKS OK" />
+        </event>
+        <event name = "PUT">
+            <action name = "store the transaction" />
+            <action name = "send" message = "PUT OK" />
+        </event>
+        <event name = "GET">
+            <action name = "retrieve the transaction" />
+            <action name = "send" message = "GET OK" />
+        </event>
+        <event name = "SAVE">
+            <action name = "send" message = "SAVE OK" />
+        </event>
+        <event name = "START">
+            <action name = "start the mining process" />
+            <action name = "send" message = "START OK" />
+        </event>
+        <event name = "STOP">
+            <action name = "stop the mining process" />
+            <action name = "send" message = "STOP OK" />
+        </event>
+    </state>
+
+    <state name = "external" inherit = "defaults">
+        <event name = "CLOSE" next = "settling">
+            <action name = "send" message = "CLOSE OK" />
+            <action name = "deregister the wallet" />
+            <action name = "allow time to settle" />
+        </event>
+        <!-- All other protocol messages are invalid -->
+        <event name = "*" next = "settling">
+            <action name = "message not valid in this state" />
+            <action name = "send" message = "ERROR" />
+            <action name = "deregister the wallet" />
+            <action name = "allow time to settle" />
+        </event>
+        <!-- Client tried to do something we don't allow yet -->
+        <event name = "exception" next = "settling">
+            <action name = "send" message = "ERROR" />
+            <action name = "deregister the wallet" />
+            <action name = "allow time to settle" />
+        </event>
+    </state>
+
+    <state name = "settling">
+        <event name = "settled">
+            <action name = "terminate" />
+        </event>
+        <event name = "OPEN" next = "connected">
+            <action name = "register new client" />
+            <action name = "send" message = "OPEN OK" />
+        </event>
+        <event name = "*">
+        </event>
+    </state>
+
+    <state name = "defaults">
+        <event name = "PING">
+            <action name = "send" message = "PING OK" />
+        </event>
+        <!-- This built-in event hits on a client timeout -->
+        <event name = "expired" next = "settling">
+            <action name = "deregister the wallet" />
+            <action name = "allow time to settle" />
+        </event>
+    </state>
+</class>

--- a/src/wap_server_engine.inc
+++ b/src/wap_server_engine.inc
@@ -1,0 +1,1279 @@
+/*  =========================================================================
+    wap_server_engine - wap_server engine
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: wap_server.xml, or
+     * The code generation script that built this file: zproto_server_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+                                                                
+    (insert license text here)                                  
+    =========================================================================
+*/
+
+
+//  ---------------------------------------------------------------------------
+//  State machine constants
+
+typedef enum {
+    start_state = 1,
+    connected_state = 2,
+    external_state = 3,
+    settling_state = 4,
+    defaults_state = 5
+} state_t;
+
+typedef enum {
+    NULL_event = 0,
+    terminate_event = 1,
+    open_event = 2,
+    blocks_event = 3,
+    put_event = 4,
+    get_event = 5,
+    save_event = 6,
+    start_event = 7,
+    stop_event = 8,
+    close_event = 9,
+    exception_event = 10,
+    settled_event = 11,
+    ping_event = 12,
+    expired_event = 13
+} event_t;
+
+//  Names for state machine logging and error reporting
+static char *
+s_state_name [] = {
+    "(NONE)",
+    "start",
+    "connected",
+    "external",
+    "settling",
+    "defaults"
+};
+
+static char *
+s_event_name [] = {
+    "(NONE)",
+    "terminate",
+    "OPEN",
+    "BLOCKS",
+    "PUT",
+    "GET",
+    "SAVE",
+    "START",
+    "STOP",
+    "CLOSE",
+    "exception",
+    "settled",
+    "PING",
+    "expired"
+};
+
+//  ---------------------------------------------------------------------------
+//  Context for the whole server task. This embeds the application-level
+//  server context at its start (the entire structure, not a reference),
+//  so we can cast a pointer between server_t and s_server_t arbitrarily.
+
+typedef struct {
+    server_t server;            //  Application-level server context
+    zsock_t *pipe;              //  Socket to back to caller API
+    zsock_t *router;            //  Socket to talk to clients
+    int port;                   //  Server port bound to
+    zloop_t *loop;              //  Reactor for server sockets
+    wap_proto_t *message;       //  Message received or sent
+    zhash_t *clients;           //  Clients we're connected to
+    zconfig_t *config;          //  Configuration tree
+    uint client_id;             //  Client identifier counter
+    size_t timeout;             //  Default client expiry timeout
+    bool verbose;               //  Verbose logging enabled?
+    char *log_prefix;           //  Default log prefix
+} s_server_t;
+
+
+//  ---------------------------------------------------------------------------
+//  Context for each connected client. This embeds the application-level
+//  client context at its start (the entire structure, not a reference),
+//  so we can cast a pointer between client_t and s_client_t arbitrarily.
+
+typedef struct {
+    client_t client;            //  Application-level client context
+    s_server_t *server;         //  Parent server context
+    char *hashkey;              //  Key into server->clients hash
+    zframe_t *routing_id;       //  Routing_id back to client
+    uint unique_id;             //  Client identifier in server
+    state_t state;              //  Current state
+    event_t event;              //  Current event
+    event_t next_event;         //  The next event
+    event_t exception;          //  Exception event, if any
+    int wakeup;                 //  zloop timer for client alarms
+    void *ticket;               //  zloop ticket for client timeouts
+    event_t wakeup_event;       //  Wake up with this event
+    char log_prefix [41];       //  Log prefix string
+} s_client_t;
+
+static int
+    server_initialize (server_t *self);
+static void
+    server_terminate (server_t *self);
+static zmsg_t *
+    server_method (server_t *self, const char *method, zmsg_t *msg);
+static int
+    client_initialize (client_t *self);
+static void
+    client_terminate (client_t *self);
+static void
+    s_client_execute (s_client_t *client, event_t event);
+static int
+    s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
+static int
+    s_client_handle_ticket (zloop_t *loop, int timer_id, void *argument);
+static void
+    register_the_wallet (client_t *self);
+static void
+    message_not_valid_in_this_state (client_t *self);
+static void
+    retrieve_the_blocks (client_t *self);
+static void
+    store_the_transaction (client_t *self);
+static void
+    retrieve_the_transaction (client_t *self);
+static void
+    start_the_mining_process (client_t *self);
+static void
+    stop_the_mining_process (client_t *self);
+static void
+    deregister_the_wallet (client_t *self);
+static void
+    allow_time_to_settle (client_t *self);
+static void
+    register_new_client (client_t *self);
+
+//  ---------------------------------------------------------------------------
+//  These methods are an internal API for actions
+
+//  Set the next event, needed in at least one action in an internal
+//  state; otherwise the state machine will wait for a message on the
+//  router socket and treat that as the event.
+
+static void
+engine_set_next_event (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->next_event = event;
+    }
+}
+
+//  Raise an exception with 'event', halting any actions in progress.
+//  Continues execution of actions defined for the exception event.
+
+static void
+engine_set_exception (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->exception = event;
+    }
+}
+
+//  Set wakeup alarm after 'delay' msecs. The next state should
+//  handle the wakeup event. The alarm is cancelled on any other
+//  event.
+
+static void
+engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        if (self->wakeup) {
+            zloop_timer_end (self->server->loop, self->wakeup);
+            self->wakeup = 0;
+        }
+        self->wakeup = zloop_timer (
+            self->server->loop, delay, 1, s_client_handle_wakeup, self);
+        self->wakeup_event = event;
+    }
+}
+
+//  Execute 'event' on specified client. Use this to send events to
+//  other clients. Cancels any wakeup alarm on that client.
+
+static void
+engine_send_event (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        s_client_execute (self, event);
+    }
+}
+
+//  Execute 'event' on all clients known to the server. If you pass a
+//  client argument, that client will not receive the broadcast. If you
+//  want to pass any arguments, store them in the server context.
+
+static void
+engine_broadcast_event (server_t *server, client_t *client, event_t event)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        zlist_t *keys = zhash_keys (self->clients);
+        char *key = (char *) zlist_first (keys);
+        while (key) {
+            s_client_t *target = (s_client_t *) zhash_lookup (self->clients, key);
+            if (target != (s_client_t *) client)
+                s_client_execute (target, event);
+            key = (char *) zlist_next (keys);
+        }
+        zlist_destroy (&keys);
+    }
+}
+
+//  Poll socket for activity, invoke handler on any received message.
+//  Handler must be a CZMQ zloop_fn function; receives server as arg.
+
+static void
+engine_handle_socket (server_t *server, zsock_t *socket, zloop_reader_fn handler)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        if (handler != NULL) {
+            int rc = zloop_reader (self->loop, socket, handler, self);
+            assert (rc == 0);
+            zloop_reader_set_tolerant (self->loop, socket);
+        }
+        else
+            zloop_reader_end (self->loop, socket);
+    }
+}
+
+//  Register monitor function that will be called at regular intervals
+//  by the server engine
+
+static void
+engine_set_monitor (server_t *server, size_t interval, zloop_timer_fn monitor)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        int rc = zloop_timer (self->loop, interval, 0, monitor, self);
+        assert (rc >= 0);
+    }
+}
+
+//  Set log file prefix; this string will be added to log data, to make
+//  log data more searchable. The string is truncated to ~20 chars.
+
+static void
+engine_set_log_prefix (client_t *client, const char *string)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+            "%6d:%-33s", self->unique_id, string);
+    }
+}
+
+//  Set a configuration value in the server's configuration tree. The
+//  properties this engine uses are: server/verbose, server/timeout, and
+//  server/background. You can also configure other abitrary properties.
+
+static void
+engine_configure (server_t *server, const char *path, const char *value)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        zconfig_put (self->config, path, value);
+    }
+}
+
+//  Return true if server is running in verbose mode, else return false.
+
+static bool
+engine_verbose (server_t *server)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        return self->verbose;
+    }
+    return false;
+}
+
+//  Pedantic compilers don't like unused functions, so we call the whole
+//  API, passing null references. It's nasty and horrid and sufficient.
+
+static void
+s_satisfy_pedantic_compilers (void)
+{
+    engine_set_next_event (NULL, NULL_event);
+    engine_set_exception (NULL, NULL_event);
+    engine_set_wakeup_event (NULL, 0, NULL_event);
+    engine_send_event (NULL, NULL_event);
+    engine_broadcast_event (NULL, NULL, NULL_event);
+    engine_handle_socket (NULL, 0, NULL);
+    engine_set_monitor (NULL, 0, NULL);
+    engine_set_log_prefix (NULL, NULL);
+    engine_configure (NULL, NULL, NULL);
+    engine_verbose (NULL);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Generic methods on protocol messages
+//  TODO: replace with lookup table, since ID is one byte
+
+static event_t
+s_protocol_event (wap_proto_t *message)
+{
+    assert (message);
+    switch (wap_proto_id (message)) {
+        case WAP_PROTO_OPEN:
+            return open_event;
+            break;
+        case WAP_PROTO_BLOCKS:
+            return blocks_event;
+            break;
+        case WAP_PROTO_PUT:
+            return put_event;
+            break;
+        case WAP_PROTO_GET:
+            return get_event;
+            break;
+        case WAP_PROTO_SAVE:
+            return save_event;
+            break;
+        case WAP_PROTO_START:
+            return start_event;
+            break;
+        case WAP_PROTO_STOP:
+            return stop_event;
+            break;
+        case WAP_PROTO_CLOSE:
+            return close_event;
+            break;
+        case WAP_PROTO_PING:
+            return ping_event;
+            break;
+        default:
+            //  Invalid wap_proto_t
+            return terminate_event;
+    }
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Client methods
+
+static s_client_t *
+s_client_new (s_server_t *server, zframe_t *routing_id)
+{
+    s_client_t *self = (s_client_t *) zmalloc (sizeof (s_client_t));
+    assert (self);
+    assert ((s_client_t *) &self->client == self);
+    
+    self->server = server;
+    self->hashkey = zframe_strhex (routing_id);
+    self->routing_id = zframe_dup (routing_id);
+    self->unique_id = server->client_id++;
+    engine_set_log_prefix (&self->client, server->log_prefix);
+
+    self->client.server = (server_t *) server;
+    self->client.message = server->message;
+
+    //  If expiry timers are being used, create client ticket
+    if (server->timeout)
+        self->ticket = zloop_ticket (server->loop, s_client_handle_ticket, self);
+    //  Give application chance to initialize and set next event
+    self->state = start_state;
+    self->event = NULL_event;
+    client_initialize (&self->client);
+    return self;
+}
+
+static void
+s_client_destroy (s_client_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        s_client_t *self = *self_p;
+        if (self->wakeup)
+            zloop_timer_end (self->server->loop, self->wakeup);
+        if (self->ticket)
+            zloop_ticket_delete (self->server->loop, self->ticket);
+        zframe_destroy (&self->routing_id);
+        //  Provide visual clue if application misuses client reference
+        engine_set_log_prefix (&self->client, "*** TERMINATED ***");
+        client_terminate (&self->client);
+        free (self->hashkey);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  Callback when we remove client from 'clients' hash table
+static void
+s_client_free (void *argument)
+{
+    s_client_t *client = (s_client_t *) argument;
+    s_client_destroy (&client);
+}
+
+
+//  Execute state machine as long as we have events
+
+static void
+s_client_execute (s_client_t *self, event_t event)
+{
+    self->next_event = event;
+    //  Cancel wakeup timer, if any was pending
+    if (self->wakeup) {
+        zloop_timer_end (self->server->loop, self->wakeup);
+        self->wakeup = 0;
+    }
+    while (self->next_event > 0) {
+        self->event = self->next_event;
+        self->next_event = NULL_event;
+        self->exception = NULL_event;
+        if (self->server->verbose) {
+            zsys_debug ("%s: %s:",
+                self->log_prefix, s_state_name [self->state]);
+            zsys_debug ("%s:     %s",
+                self->log_prefix, s_event_name [self->event]);
+        }
+        switch (self->state) {
+            case start_state:
+                if (self->event == open_event) {
+                    if (!self->exception) {
+                        //  register the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ register the wallet", self->log_prefix);
+                        register_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OPEN_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OPEN_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_OPEN_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == close_event) {
+                    if (!self->exception) {
+                        //  send CLOSE_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send CLOSE_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_CLOSE_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == ping_event) {
+                    if (!self->exception) {
+                        //  send PING_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send PING_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_PING_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                break;
+
+            case connected_state:
+                if (self->event == blocks_event) {
+                    if (!self->exception) {
+                        //  retrieve the blocks
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ retrieve the blocks", self->log_prefix);
+                        retrieve_the_blocks (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send BLOCKS_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send BLOCKS_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_BLOCKS_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == put_event) {
+                    if (!self->exception) {
+                        //  store the transaction
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ store the transaction", self->log_prefix);
+                        store_the_transaction (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send PUT_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send PUT_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_PUT_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == get_event) {
+                    if (!self->exception) {
+                        //  retrieve the transaction
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ retrieve the transaction", self->log_prefix);
+                        retrieve_the_transaction (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send GET_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send GET_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_GET_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == save_event) {
+                    if (!self->exception) {
+                        //  send SAVE_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send SAVE_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_SAVE_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == start_event) {
+                    if (!self->exception) {
+                        //  start the mining process
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ start the mining process", self->log_prefix);
+                        start_the_mining_process (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send START_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send START_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_START_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == stop_event) {
+                    if (!self->exception) {
+                        //  stop the mining process
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ stop the mining process", self->log_prefix);
+                        stop_the_mining_process (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send STOP_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send STOP_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_STOP_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == close_event) {
+                    if (!self->exception) {
+                        //  send CLOSE_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send CLOSE_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_CLOSE_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == ping_event) {
+                    if (!self->exception) {
+                        //  send PING_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send PING_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_PING_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                break;
+
+            case external_state:
+                if (self->event == close_event) {
+                    if (!self->exception) {
+                        //  send CLOSE_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send CLOSE_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_CLOSE_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else
+                if (self->event == ping_event) {
+                    if (!self->exception) {
+                        //  send PING_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send PING_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_PING_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_ERROR);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                break;
+
+            case settling_state:
+                if (self->event == settled_event) {
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == open_event) {
+                    if (!self->exception) {
+                        //  register new client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ register new client", self->log_prefix);
+                        register_new_client (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OPEN_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OPEN_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_OPEN_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else {
+                    //  Handle unexpected protocol events
+                }
+                break;
+
+            case defaults_state:
+                if (self->event == ping_event) {
+                    if (!self->exception) {
+                        //  send PING_OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send PING_OK",
+                                self->log_prefix);
+                        wap_proto_set_id (self->server->message, WAP_PROTO_PING_OK);
+                        wap_proto_set_routing_id (self->server->message, self->routing_id);
+                        wap_proto_send (self->server->message, self->server->router);
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  deregister the wallet
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the wallet", self->log_prefix);
+                        deregister_the_wallet (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  allow time to settle
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ allow time to settle", self->log_prefix);
+                        allow_time_to_settle (&self->client);
+                    }
+                    if (!self->exception)
+                        self->state = settling_state;
+                }
+                else {
+                    //  Handle unexpected internal events
+                    zsys_warning ("%s: unhandled event %s in %s",
+                        self->log_prefix,
+                        s_event_name [self->event],
+                        s_state_name [self->state]);
+                    assert (false);
+                }
+                break;
+        }
+        //  If we had an exception event, interrupt normal programming
+        if (self->exception) {
+            if (self->server->verbose)
+                zsys_debug ("%s:         ! %s",
+                    self->log_prefix, s_event_name [self->exception]);
+
+            self->next_event = self->exception;
+        }
+        if (self->next_event == terminate_event) {
+            //  Automatically calls s_client_destroy
+            zhash_delete (self->server->clients, self->hashkey);
+            break;
+        }
+        else
+        if (self->server->verbose)
+            zsys_debug ("%s:         > %s",
+                self->log_prefix, s_state_name [self->state]);
+    }
+}
+
+//  zloop callback when client ticket expires
+
+static int
+s_client_handle_ticket (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, expired_event);
+    self->ticket = NULL;        //  Ticket is now dead
+    return 0;
+}
+
+//  zloop callback when client wakeup timer expires
+
+static int
+s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, self->wakeup_event);
+    return 0;
+}
+
+
+//  Server methods
+
+static void
+s_server_config_global (s_server_t *self)
+{
+    //  Built-in server configuration options
+    //  
+    //  If we didn't already set verbose, check if the config tree wants it
+    if (!self->verbose
+    && atoi (zconfig_resolve (self->config, "server/verbose", "0")))
+        self->verbose = true;
+        
+    //  Default client timeout is 60 seconds
+    self->timeout = atoi (
+        zconfig_resolve (self->config, "server/timeout", "60000"));
+    zloop_set_ticket_delay (self->loop, self->timeout);
+    
+    //  Do we want to run server in the background?
+    int background = atoi (
+        zconfig_resolve (self->config, "server/background", "0"));
+    if (!background)
+        zsys_set_logstream (stdout);
+}
+
+static s_server_t *
+s_server_new (zsock_t *pipe)
+{
+    s_server_t *self = (s_server_t *) zmalloc (sizeof (s_server_t));
+    assert (self);
+    assert ((s_server_t *) &self->server == self);
+
+    self->pipe = pipe;
+    self->router = zsock_new (ZMQ_ROUTER);
+    //  By default the socket will discard outgoing messages above the
+    //  HWM of 1,000. This isn't helpful for high-volume streaming. We
+    //  will use a unbounded queue here. If applications need to guard
+    //  against queue overflow, they should use a credit-based flow
+    //  control scheme.
+    zsock_set_unbounded (self->router);
+    self->message = wap_proto_new ();
+    self->clients = zhash_new ();
+    self->config = zconfig_new ("root", NULL);
+    self->loop = zloop_new ();
+    srandom ((unsigned int) zclock_time ());
+    self->client_id = randof (1000);
+    s_server_config_global (self);
+
+    //  Initialize application server context
+    self->server.pipe = self->pipe;
+    self->server.config = self->config;
+    server_initialize (&self->server);
+
+    s_satisfy_pedantic_compilers ();
+    return self;
+}
+
+static void
+s_server_destroy (s_server_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        s_server_t *self = *self_p;
+        wap_proto_destroy (&self->message);
+        //  Destroy clients before destroying the server
+        zhash_destroy (&self->clients);
+        server_terminate (&self->server);
+        zsock_destroy (&self->router);
+        zconfig_destroy (&self->config);
+        zloop_destroy (&self->loop);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  Apply service-specific configuration tree:
+//   * apply server configuration
+//   * print any echo items in top-level sections
+//   * apply sections that match methods
+
+static void
+s_server_config_service (s_server_t *self)
+{
+    //  Apply echo commands and class methods
+    zconfig_t *section = zconfig_locate (self->config, "wap_server");
+    if (section)
+        section = zconfig_child (section);
+
+    while (section) {
+        if (streq (zconfig_name (section), "echo"))
+            zsys_notice ("%s", zconfig_value (section));
+        else
+        if (streq (zconfig_name (section), "bind")) {
+            char *endpoint = zconfig_resolve (section, "endpoint", "?");
+            if (zsock_bind (self->router, "%s", endpoint) == -1)
+                zsys_warning ("could not bind to %s (%s)", endpoint, zmq_strerror (zmq_errno ()));
+        }
+        else
+        if (streq (zconfig_name (section), "security")) {
+            char *mechanism = zconfig_resolve (section, "mechanism", "null");
+            char *domain = zconfig_resolve (section, "domain", NULL);
+            if (streq (mechanism, "null")) {
+                if (domain)
+                    zsock_set_zap_domain (self->router, NULL);
+            }
+            else
+            if (streq (mechanism, "plain"))
+                zsock_set_plain_server (self->router, 1);
+            else
+                zsys_warning ("mechanism=%s is not supported", mechanism);
+        }
+        section = zconfig_next (section);
+    }
+    s_server_config_global (self);
+}
+
+//  Process message from pipe
+
+static int
+s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    zmsg_t *msg = zmsg_recv (self->pipe);
+    if (!msg)
+        return -1;              //  Interrupted; exit zloop
+    char *method = zmsg_popstr (msg);
+    if (self->verbose)
+        zsys_debug ("%s:     API command=%s", self->log_prefix, method);
+
+    if (streq (method, "VERBOSE"))
+        self->verbose = true;
+    else
+    if (streq (method, "$TERM")) {
+        //  Shutdown the engine
+        free (method);
+        zmsg_destroy (&msg);
+        return -1;
+    }
+    else
+    if (streq (method, "BIND")) {
+        //  Bind to a specified endpoint, which may use an ephemeral port
+        char *endpoint = zmsg_popstr (msg);
+        self->port = zsock_bind (self->router, "%s", endpoint);
+        if (self->port == -1)
+            zsys_warning ("could not bind to %s", endpoint);
+        free (endpoint);
+    }
+    else
+    if (streq (method, "PORT")) {
+        //  Return PORT + port number from the last bind, if any
+        zstr_sendm (self->pipe, "PORT");
+        zstr_sendf (self->pipe, "%d", self->port);
+    }
+    else
+    if (streq (method, "CONFIGURE")) {
+        char *config_file = zmsg_popstr (msg);
+        zconfig_destroy (&self->config);
+        self->config = zconfig_load (config_file);
+        if (self->config) {
+            s_server_config_service (self);
+            self->server.config = self->config;
+        }
+        else {
+            zsys_warning ("cannot load config file '%s'\n", config_file);
+            self->config = zconfig_new ("root", NULL);
+        }
+        free (config_file);
+    }
+    else
+    if (streq (method, "SET")) {
+        char *path = zmsg_popstr (msg);
+        char *value = zmsg_popstr (msg);
+        zconfig_put (self->config, path, value);
+        if (streq (path, "server/animate")) {
+            zsys_warning ("'%s' is deprecated, use VERBOSE command instead", path);
+            self->verbose = atoi (value);
+        }
+        s_server_config_global (self);
+        free (path);
+        free (value);
+    }
+    else {
+        //  Execute custom method
+        zmsg_t *reply = server_method (&self->server, method, msg);
+        //  If reply isn't null, send it to caller
+        zmsg_send (&reply, self->pipe);
+    }
+    free (method);
+    zmsg_destroy (&msg);
+    return 0;
+}
+
+//  Handle a protocol message from the client
+
+static int
+s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    //  We process as many messages as we can, to reduce the overhead
+    //  of polling and the reactor:
+    while (zsock_events (self->router) & ZMQ_POLLIN) {
+        if (wap_proto_recv (self->message, self->router))
+            return -1;              //  Interrupted; exit zloop
+
+        //  TODO: use binary hashing on routing_id
+        char *hashkey = zframe_strhex (wap_proto_routing_id (self->message));
+        s_client_t *client = (s_client_t *) zhash_lookup (self->clients, hashkey);
+        if (client == NULL) {
+            client = s_client_new (self, wap_proto_routing_id (self->message));
+            zhash_insert (self->clients, hashkey, client);
+            zhash_freefn (self->clients, hashkey, s_client_free);
+        }
+        free (hashkey);
+        //  Any input from client counts as activity
+        if (client->ticket)
+            zloop_ticket_reset (self->loop, client->ticket);
+        
+        //  Pass to client state machine
+        s_client_execute (client, s_protocol_event (self->message));
+    }
+    return 0;
+}
+
+//  Watch server config file and reload if changed
+
+static int
+s_watch_server_config (zloop_t *loop, int timer_id, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    if (zconfig_has_changed (self->config)
+    &&  zconfig_reload (&self->config) == 0) {
+        s_server_config_service (self);
+        self->server.config = self->config;
+        zsys_notice ("reloaded configuration from %s",
+            zconfig_filename (self->config));
+    }
+    return 0;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  This is the server actor, which polls its two sockets and processes
+//  incoming messages
+
+void
+wap_server (zsock_t *pipe, void *args)
+{
+    //  Initialize
+    s_server_t *self = s_server_new (pipe);
+    assert (self);
+    zsock_signal (pipe, 0);
+    //  Actor argument may be a string used for logging
+    self->log_prefix = args? (char *) args: "";
+
+    //  Set-up server monitor to watch for config file changes
+    engine_set_monitor ((server_t *) self, 1000, s_watch_server_config);
+    //  Set up handler for the two main sockets the server uses
+    engine_handle_socket ((server_t *) self, self->pipe, s_server_handle_pipe);
+    engine_handle_socket ((server_t *) self, self->router, s_server_handle_protocol);
+
+    //  Run reactor until there's a termination signal
+    zloop_start (self->loop);
+
+    //  Reactor has ended
+    s_server_destroy (&self);
+}

--- a/src/wap_tutorial.c
+++ b/src/wap_tutorial.c
@@ -1,0 +1,75 @@
+/*  =========================================================================
+    wap_tutorial.c - Wallet access protocol tutorial
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+
+    
+    =========================================================================
+*/
+
+/*
+@header
+    This actor implements the Malamute service. The actor uses the CZMQ socket
+    command interface, rather than a classic C API. You can start as many
+    instances of the Malamute service as you like. Each will run in its own
+    namespace, as virtual hosts. This class is wrapped as a main program via
+    the malamute.c application, and can be wrapped in other languages in the
+    same way as any C API.
+@discuss
+    This is a minimal, incomplete implementation of Malamute. It does however
+    not have any known bugs.
+@end
+*/
+
+//  This header file gives us the Wallet APIs plus CZMQ, and libzmq:
+#include "../include/wallet.h"
+
+int main (int argc, char *argv [])
+{
+    //  Let's start a new server instance; this runs as a background thread
+    zactor_t *server = zactor_new (wap_server, NULL);
+
+    //  Switch on verbose tracing... this gets a little overwhelming so you
+    //  can comment or delete this when you're bored with it:
+    zsock_send (server, "s", "VERBOSE");
+
+    //  We control the server by sending it commands. It's a CZMQ actor, and
+    //  we can talk to it using the zsock API (or zstr, or zframe, or zmsg).
+    //  To get things started, let's tell the server to bind to an endpoint:
+    zsock_send (server, "ss", "BIND", "ipc://@/monero");
+
+    //  We can set server properties by sending it SET commands like this:
+    //  (Or, configure the server via an external config file)
+    zsock_send (server, "sss", "SET", "server/timeout", "5000");
+
+    //  The server is now running. Let's start a wallet client:
+    wap_client_t *client = wap_client_new ("ipc://@/monero", 200, "wallet identity");
+    assert (client);
+    
+    //  Switch on client tracing, we'll now see both the client and the
+    //  server state machines animated:
+    wap_client_verbose (client);
+
+    //  Note that the client provides an method API, which wraps the internal
+    //  actor API. This is just to make it easier for naive users. You could
+    //  talk directly to the client actor (as we do for the server), and this
+    //  has the same effect:
+    zsock_send (wap_client_actor (client), "s", "VERBOSE");
+    
+    //  The server only supports two commands for now, START and STOP, so
+    //  let's try each of these:
+    int rc = wap_client_start (client);
+    assert (rc == 0);
+
+    rc = wap_client_stop (client);
+    assert (rc == 0);
+    
+    //  Great, it all works. Now to shutdown, we use the destroy method,
+    //  which does a proper deconnect handshake internally:
+    wap_client_destroy (&client);
+
+    //  Finally, shut down the server by destroying the actor; this does
+    //  a proper shutdown so that all memory is freed as you'd expect.
+    zactor_destroy (&server);
+    return 0;
+}


### PR DESCRIPTION
Solution: implement basic server and client stacks. These models are in
wap_server.xml and wap_client.xml, with the C code is in wap_server.c
and wap_client.c.

You can read src/wap_tutorial.c for a line by line explanation, and you
can run this to see the two sides talking to each other.

For now the only commands the client API implements are START and STOP.
The server does nothing with these right now. However you can see the
placeholders in wap_server.c.