### PR TITLE
Problem: need example of passing method arguments

### DIFF
--- a/include/wap_client.h
+++ b/include/wap_client.h
@@ -77,7 +77,7 @@ WAP_EXPORT int
 //  Send start command to server.                                                   
 //  Returns >= 0 if successful, -1 if interrupted.
 WAP_EXPORT int 
-    wap_client_start (wap_client_t *self, uint64_t start_height);
+    wap_client_start (wap_client_t *self, uint32_t start_height);
 
 //  Send stop command to server.                                                    
 //  Returns >= 0 if successful, -1 if interrupted.

--- a/include/wap_proto.h
+++ b/include/wap_proto.h
@@ -35,8 +35,8 @@ BLOCKS-OK, or ERROR if the request is invalid.
         block_ids           strings     
 
     BLOCKS_OK - Daemon returns a set of blocks to the wallet.
-        start_height        number 8    
-        curr_height         number 8    
+        start_height        number 4    
+        curr_height         number 4    
         block_status        string      
         block_data          msg         Frames of block data
 
@@ -60,9 +60,10 @@ with GET-OK, or ERROR.
 
     START - Wallet asks daemon to start mining. Daemon replies with START-OK, or
 ERROR.
-        start_height        number 8    
+        start_height        number 4    
 
     START_OK - Daemon replies to a start mining request.
+        curr_height         number 4    
 
     STOP - Wallet asks daemon to start mining. Daemon replies with START-OK, or
 ERROR.
@@ -180,16 +181,16 @@ void
     wap_proto_set_block_ids (wap_proto_t *self, zlist_t **block_ids_p);
 
 //  Get/set the start_height field
-uint64_t
+uint32_t
     wap_proto_start_height (wap_proto_t *self);
 void
-    wap_proto_set_start_height (wap_proto_t *self, uint64_t start_height);
+    wap_proto_set_start_height (wap_proto_t *self, uint32_t start_height);
 
 //  Get/set the curr_height field
-uint64_t
+uint32_t
     wap_proto_curr_height (wap_proto_t *self);
 void
-    wap_proto_set_curr_height (wap_proto_t *self, uint64_t curr_height);
+    wap_proto_set_curr_height (wap_proto_t *self, uint32_t curr_height);
 
 //  Get/set the block_status field
 const char *

--- a/src/wap_client.c
+++ b/src/wap_client.c
@@ -177,7 +177,7 @@ prepare_get_command (client_t *self)
 static void
 signal_have_get_ok (client_t *self)
 {
-    zsock_send (self->cmdpipe, "sip", "GET OK", 0, 
+    zsock_send (self->cmdpipe, "sip", "GET OK", 0,
                 wap_proto_get_tx_data (self->message));
 }
 
@@ -191,6 +191,16 @@ prepare_save_command (client_t *self)
 {
 }
 
+
+//  ---------------------------------------------------------------------------
+//  prepare_start_command
+//
+
+static void
+prepare_start_command (client_t *self)
+{
+    wap_proto_set_start_height (self->message, self->args->start_height);
+}
 
 
 //  ---------------------------------------------------------------------------
@@ -211,7 +221,8 @@ signal_have_save_ok (client_t *self)
 static void
 signal_have_start_ok (client_t *self)
 {
-    zsock_send (self->cmdpipe, "si", "START OK", 0);
+    zsock_send (self->cmdpipe, "sii", "START OK", 0,
+                wap_proto_curr_height (self->message));
 }
 
 
@@ -316,8 +327,9 @@ wap_client_test (bool verbose)
     wap_client_t *client = wap_client_new ("ipc://@/monero", 1000, "test client");
     assert (client);
 
-    int rc = wap_client_start (client, 0);
+    int rc = wap_client_start (client, 123);
     assert (rc == 0);
+    assert (wap_client_curr_height (client) == 123);
     rc = wap_client_stop (client);
     assert (rc == 0);
     

--- a/src/wap_client.xml
+++ b/src/wap_client.xml
@@ -52,6 +52,7 @@
             <action name = "send" message = "SAVE" />
         </event>
         <event name = "start" next = "expect start ok">
+            <action name = "prepare start command" />
             <action name = "send" message = "START" />
         </event>
         <event name = "stop" next = "expect stop ok">
@@ -219,13 +220,14 @@
 
     <method name = "start" return = "status">
     Send start command to server.
-        <field name = "start height" type = "number" size = "8" />
+        <field name = "start height" type = "number" size = "4" />
         <accept reply = "START OK" />
         <accept reply = "FAILURE" />
     </method>
 
     <reply name = "START OK">
         <field name = "status" type = "integer" />
+        <field name = "curr height" type = "number" size = "4" />
     </reply>
 
     <method name = "stop" return = "status">

--- a/src/wap_client_engine.inc
+++ b/src/wap_client_engine.inc
@@ -122,7 +122,7 @@ struct _client_args_t {
     zlist_t *block_ids;
     zchunk_t *tx_data;
     char *tx_id;
-    uint64_t start_height;
+    uint32_t start_height;
 };
 
 typedef struct {
@@ -180,6 +180,8 @@ static void
     prepare_put_command (client_t *self);
 static void
     prepare_save_command (client_t *self);
+static void
+    prepare_start_command (client_t *self);
 static void
     signal_have_blocks_ok (client_t *self);
 static void
@@ -615,6 +617,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == start_event) {
+                    if (!self->exception) {
+                        //  prepare start command
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ prepare start command");
+                        prepare_start_command (&self->client);
+                    }
                     if (!self->exception) {
                         //  send START
                         if (wap_client_verbose)
@@ -1344,7 +1352,7 @@ s_accept_reply (wap_client_t *self, ...)
                 }
                 else
                 if (streq (reply, "START OK")) {
-                    zsock_recv (self->actor, "i", &self->status);
+                    zsock_recv (self->actor, "ii", &self->status, &self->curr_height);
                 }
                 else
                 if (streq (reply, "STOP OK")) {
@@ -1466,7 +1474,7 @@ wap_client_save (wap_client_t *self)
 //  Returns >= 0 if successful, -1 if interrupted.
 
 int 
-wap_client_start (wap_client_t *self, uint64_t start_height)
+wap_client_start (wap_client_t *self, uint32_t start_height)
 {
     assert (self);
     zsock_send (self->actor, "si", "START", start_height);

--- a/src/wap_proto.bnf
+++ b/src/wap_proto.bnf
@@ -32,37 +32,37 @@ The following ABNF grammar defines the Wallet Access Protocol:
     ;  Wallet requests a set of blocks from the daemon. Daemon replies with  
     ;  BLOCKS-OK, or ERROR if the request is invalid.                        
 
-    BLOCKS          = signature %d3 block ids
+    BLOCKS          = signature %d3 block_ids
     block ids       = strings               ; 
 
     ;  Daemon returns a set of blocks to the wallet.                         
 
-    BLOCKS-OK       = signature %d4 start height curr height block status block data
-    start height    = number-8              ; 
-    curr height     = number-8              ; 
+    BLOCKS-OK       = signature %d4 start_height curr_height block_status block_data
+    start height    = number-4              ; 
+    curr height     = number-4              ; 
     block status    = string                ; 
     block data      = msg                   ; Frames of block data
 
     ;  Wallet sends a raw transaction to the daemon. Daemon replies with     
     ;  PUT-OK, or ERROR.                                                     
 
-    PUT             = signature %d5 tx data
+    PUT             = signature %d5 tx_data
     tx data         = chunk                 ; Transaction data
 
     ;  Daemon confirms that it accepted the raw transaction.                 
 
-    PUT-OK          = signature %d6 tx id
+    PUT-OK          = signature %d6 tx_id
     tx id           = string                ; Transaction ID
 
     ;  Wallet requests transaction data from the daemon. Daemon replies with 
     ;  GET-OK, or ERROR.                                                     
 
-    GET             = signature %d7 tx id
+    GET             = signature %d7 tx_id
     tx id           = string                ; Transaction ID
 
     ;  Daemon replies with transaction data.                                 
 
-    GET-OK          = signature %d8 tx data
+    GET-OK          = signature %d8 tx_data
     tx data         = chunk                 ; Transaction data
 
     ;  save_bc command. Details tbd.                                         
@@ -76,12 +76,13 @@ The following ABNF grammar defines the Wallet Access Protocol:
     ;  Wallet asks daemon to start mining. Daemon replies with START-OK, or  
     ;  ERROR.                                                                
 
-    START           = signature %d11 start height
-    start height    = number-8              ; 
+    START           = signature %d11 start_height
+    start height    = number-4              ; 
 
     ;  Daemon replies to a start mining request.                             
 
-    START-OK        = signature %d12
+    START-OK        = signature %d12 curr_height
+    curr height     = number-4              ; 
 
     ;  Wallet asks daemon to start mining. Daemon replies with START-OK, or  
     ;  ERROR.                                                                
@@ -134,4 +135,3 @@ The following ABNF grammar defines the Wallet Access Protocol:
     number-1        = 1OCTET
     number-2        = 2OCTET
     number-4        = 4OCTET
-    number-8        = 8OCTET

--- a/src/wap_proto.xml
+++ b/src/wap_proto.xml
@@ -46,8 +46,8 @@
 
     <message name = "BLOCKS-OK">
         Daemon returns a set of blocks to the wallet.
-        <field name = "start height" type = "number" size = "8" />
-        <field name = "curr height" type = "number" size = "8" />
+        <field name = "start height" type = "number" size = "4" />
+        <field name = "curr height" type = "number" size = "4" />
         <field name = "block status" type = "string" />
         <field name = "block data" type = "msg">Frames of block data</field>
     </message>
@@ -85,11 +85,12 @@
     <message name = "START">
         Wallet asks daemon to start mining. Daemon replies with START-OK, or
         ERROR.
-        <field name = "start height" type = "number" size = "8" />
+        <field name = "start height" type = "number" size = "4" />
     </message>
 
     <message name = "START-OK">
         Daemon replies to a start mining request.
+        <field name = "curr height" type = "number" size = "4" />
     </message>
 
     <message name = "STOP">

--- a/src/wap_server.c
+++ b/src/wap_server.c
@@ -182,7 +182,7 @@ retrieve_the_transaction (client_t *self)
 static void
 start_the_mining_process (client_t *self)
 {
-
+    wap_proto_set_curr_height (self->message, wap_proto_start_height (self->message));
 }
 
 


### PR DESCRIPTION
Solution: extend START and START-OK commands with height argument
that the server can echo back to client. See wap_client.c test case
for this.