### PR TITLE
Problem: client stack does not report connected status

### DIFF
--- a/include/wap_client.h
+++ b/include/wap_client.h
@@ -54,6 +54,12 @@ WAP_EXPORT zactor_t *
 WAP_EXPORT zsock_t *
     wap_client_msgpipe (wap_client_t *self);
 
+//  Return true if client is currently connected, else false. Note that the
+//  client will automatically re-connect if the server dies and restarts after
+//  a successful first connection.
+WAP_EXPORT bool
+    wap_client_connected (wap_client_t *self);
+
 //  Connect to server endpoint, with specified timeout in msecs (zero means wait    
 //  forever). Constructor succeeds if connection is successful. The caller may      
 //  specify its address.                                                            

--- a/include/wap_proto.h
+++ b/include/wap_proto.h
@@ -1,6 +1,6 @@
 /*  =========================================================================
     wap_proto - Wallet Access Protocol
-    
+
     Codec header for wap_proto.
 
     ** WARNING *************************************************************
@@ -166,7 +166,7 @@ int
 //  Send the wap_proto to the output socket, does not destroy it
 int
     wap_proto_send (wap_proto_t *self, zsock_t *output);
-    
+
 //  Print contents of message to stdout
 void
     wap_proto_print (wap_proto_t *self);

--- a/src/wap_client.c
+++ b/src/wap_client.c
@@ -16,9 +16,6 @@
 */
 
 #include "wap_classes.h"
-//  TODO: Change these to match your project's needs
-#include "../include/wap_proto.h"
-#include "../include/wap_client.h"
 
 //  Forward reference to method arguments structure
 typedef struct _client_args_t client_args_t;
@@ -37,6 +34,7 @@ typedef struct {
     
     //  Own properties
     int heartbeat_timer;        //  Timeout for heartbeats to server
+    int retries;                //  How many heartbeats we've tried
 } client_t;
 
 //  Include the generated client engine
@@ -99,15 +97,32 @@ use_connect_timeout (client_t *self)
 
 
 //  ---------------------------------------------------------------------------
-//  use_heartbeat_timer
+//  client_is_connected
 //
 
 static void
-use_heartbeat_timer (client_t *self)
+client_is_connected (client_t *self)
 {
+    self->retries = 0;
+    engine_set_connected (self, true);
     engine_set_timeout (self, self->heartbeat_timer);
 }
 
+
+//  ---------------------------------------------------------------------------
+//  check_if_connection_is_dead
+//
+
+static void
+check_if_connection_is_dead (client_t *self)
+{
+    //  We send at most 3 heartbeats before expiring the server
+    if (++self->retries >= 3) {
+        engine_set_timeout (self, 0);
+        engine_set_connected (self, false);
+        engine_set_exception (self, exception_event);
+    }
+}
 
 
 //  ---------------------------------------------------------------------------

--- a/src/wap_client.xml
+++ b/src/wap_client.xml
@@ -26,7 +26,7 @@
     <state name = "expect open ok" inherit = "defaults">
         <event name = "OPEN OK" next = "connected">
             <action name = "signal success" />
-            <action name = "use heartbeat timer" />
+            <action name = "client is connected" />
         </event>
         <event name = "expired">
             <action name = "signal server not present" />
@@ -70,6 +70,7 @@
             <action name = "send" message = "CLOSE" />
         </event>
         <event name = "expired">
+            <action name = "check if connection is dead" />
             <action name = "send" message = "PING" />
         </event>
     </state>
@@ -135,9 +136,13 @@
 
     <state name = "defaults">
         <event name = "PING OK">
+            <action name = "client is connected" />
         </event>
         <event name = "ERROR" next = "have error">
             <action name = "check status code" />
+        </event>
+        <event name = "exception">
+            <!-- Generic exception event to interrupt actions -->
         </event>
         <event name = "*">
             <!-- Discard any other incoming events -->
@@ -157,7 +162,7 @@
    
     <state name = "reexpect open ok" inherit = "defaults">
         <event name = "OPEN OK" next = "connected">
-            <action name = "use heartbeat timer" />
+            <action name = "client is connected" />
         </event>
     </state>
 

--- a/src/wap_client_engine.inc
+++ b/src/wap_client_engine.inc
@@ -64,8 +64,9 @@ typedef enum {
     close_ok_event = 22,
     ping_ok_event = 23,
     error_event = 24,
-    command_invalid_event = 25,
-    other_event = 26
+    exception_event = 25,
+    command_invalid_event = 26,
+    other_event = 27
 } event_t;
 
 //  Names for state machine logging and error reporting
@@ -116,6 +117,7 @@ s_event_name [] = {
     "CLOSE_OK",
     "PING_OK",
     "ERROR",
+    "exception",
     "command_invalid",
     "other"
 };
@@ -149,6 +151,7 @@ typedef struct {
     zloop_t *loop;              //  Listen to pipe and dealer
     wap_proto_t *message;       //  Message received or sent
     client_args_t args;         //  Method arguments structure
+    bool connected;             //  True if client is connected
     bool terminated;            //  True if client is shutdown
     bool fsm_stopped;           //  "terminate" action called
     size_t timeout;             //  inactivity timeout, msecs
@@ -186,7 +189,7 @@ static void
 static void
     signal_success (client_t *self);
 static void
-    use_heartbeat_timer (client_t *self);
+    client_is_connected (client_t *self);
 static void
     signal_server_not_present (client_t *self);
 static void
@@ -203,6 +206,8 @@ static void
     prepare_get_output_indexes_command (client_t *self);
 static void
     prepare_get_random_outs_command (client_t *self);
+static void
+    check_if_connection_is_dead (client_t *self);
 static void
     signal_have_blocks_ok (client_t *self);
 static void
@@ -335,9 +340,11 @@ engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
     }
 }
 
-//  Set timeout for next protocol read. By default, will wait forever
-//  or until the process is interrupted. The timeout is in milliseconds.
-//  The state machine must handle the "expired" event.
+//  Set heartbeat timeout. By default, the timeout is zero, meaning
+//  infinite. Setting a non-zero timeout causes the state machine to
+//  receive an "expired" event if is no incoming traffic for that many
+//  milliseconds. This cycles over and over until/unless the code sets
+//  a zero timeout. The state machine must handle the "expired" event.
 
 static void
 engine_set_timeout (client_t *client, size_t timeout)
@@ -345,6 +352,10 @@ engine_set_timeout (client_t *client, size_t timeout)
     if (client) {
         s_client_t *self = (s_client_t *) client;
         self->timeout = timeout;
+        if (self->expiry_timer) {
+            zloop_timer_end (self->loop, self->expiry_timer);
+            self->expiry_timer = 0;
+        }
         if (self->timeout)
             self->expiry_timer = zloop_timer (
                 self->loop, self->timeout, 1, s_client_handle_timeout, self);
@@ -366,6 +377,18 @@ engine_handle_socket (client_t *client, zsock_t *sock, zloop_reader_fn handler)
         }
         else
             zloop_reader_end (self->loop, sock);
+    }
+}
+
+//  Set connected to true/false. The client must call this if it wants
+//  to provide the API with the connected status.
+
+static void
+engine_set_connected (client_t *client, bool connected)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->connected = connected;
     }
 }
 
@@ -545,10 +568,10 @@ s_client_execute (s_client_t *self, event_t event)
                         signal_success (&self->client);
                     }
                     if (!self->exception) {
-                        //  use heartbeat timer
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ use heartbeat timer");
-                        use_heartbeat_timer (&self->client);
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
                     }
                     if (!self->exception)
                         self->state = connected_state;
@@ -570,9 +593,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -584,6 +610,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -746,6 +778,12 @@ s_client_execute (s_client_t *self, event_t event)
                 else
                 if (self->event == expired_event) {
                     if (!self->exception) {
+                        //  check if connection is dead
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ check if connection is dead");
+                        check_if_connection_is_dead (&self->client);
+                    }
+                    if (!self->exception) {
                         //  send PING
                         if (wap_client_verbose)
                             zsys_debug ("wap_client:            $ send PING");
@@ -755,9 +793,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -769,6 +810,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -791,9 +838,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -805,6 +855,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -827,9 +883,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -841,6 +900,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -863,9 +928,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -877,6 +945,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -899,9 +973,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -913,6 +990,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -935,9 +1018,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -949,6 +1035,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -971,9 +1063,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -985,6 +1080,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1007,9 +1108,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -1021,6 +1125,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1043,9 +1153,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -1057,6 +1170,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1098,9 +1217,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -1112,6 +1234,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1123,9 +1251,12 @@ s_client_execute (s_client_t *self, event_t event)
 
             case defaults_state:
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -1137,6 +1268,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1190,19 +1327,22 @@ s_client_execute (s_client_t *self, event_t event)
             case reexpect_open_ok_state:
                 if (self->event == open_ok_event) {
                     if (!self->exception) {
-                        //  use heartbeat timer
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ use heartbeat timer");
-                        use_heartbeat_timer (&self->client);
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
                     }
                     if (!self->exception)
                         self->state = connected_state;
                 }
                 else
                 if (self->event == ping_ok_event) {
-                        //  No action - just logging
+                    if (!self->exception) {
+                        //  client is connected
                         if (wap_client_verbose)
-                            zsys_debug ("wap_client:            $ ping_ok");
+                            zsys_debug ("wap_client:            $ client is connected");
+                        client_is_connected (&self->client);
+                    }
                 }
                 else
                 if (self->event == error_event) {
@@ -1214,6 +1354,12 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                     if (!self->exception)
                         self->state = have_error_state;
+                }
+                else
+                if (self->event == exception_event) {
+                        //  No action - just logging
+                        if (wap_client_verbose)
+                            zsys_debug ("wap_client:            $ exception");
                 }
                 else {
                     //  Handle unexpected protocol events
@@ -1242,7 +1388,13 @@ s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument)
 {
     s_client_t *self = (s_client_t *) argument;
     s_client_execute (self, expired_event);
-    return self->terminated? -1: 0;
+    if (self->terminated)
+        return -1;
+
+    if (self->timeout > 0)
+        self->expiry_timer = zloop_timer (
+            loop, self->timeout, 1, s_client_handle_timeout, self);
+    return 0;
 }
 
 //  zloop callback when client wakeup timer expires
@@ -1270,6 +1422,9 @@ s_client_handle_cmdpipe (zloop_t *loop, zsock_t *reader, void *argument)
 
     if (streq (method, "$TERM"))
         self->terminated = true;    //  Shutdown the engine
+    else
+    if (streq (method, "$CONNECTED"))
+        zsock_send (self->cmdpipe, "i", self->connected);
     else
     if (streq (method, "CONNECT")) {
         zstr_free (&self->args.endpoint);
@@ -1436,6 +1591,7 @@ wap_client (zsock_t *cmdpipe, void *msgpipe)
 struct _wap_client_t {
     zactor_t *actor;            //  Client actor
     zsock_t *msgpipe;           //  Pipe for async message flow
+    bool connected;             //  Client currently connected or not
     int status;                 //  Returned by actor reply
     char *reason;               //  Returned by actor reply
     uint64_t start_height;      //  Returned by actor reply
@@ -1526,6 +1682,22 @@ wap_client_msgpipe (wap_client_t *self)
 {
     assert (self);
     return self->msgpipe;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Return true if client is currently connected, else false. Note that the
+//  client will automatically re-connect if the server dies and restarts after
+//  a successful first connection.
+
+bool
+wap_client_connected (wap_client_t *self)
+{
+    assert (self);
+    bool connected;
+    zsock_send (self->actor, "s", "$CONNECTED");
+    zsock_recv (self->actor, "i", &connected);
+    return connected;
 }
 
 

--- a/src/wap_proto.c
+++ b/src/wap_proto.c
@@ -34,37 +34,37 @@ struct _wap_proto_t {
     int id;                             //  wap_proto message ID
     byte *needle;                       //  Read/write pointer for serialization
     byte *ceiling;                      //  Valid upper limit for read pointer
-    /* Wallet identity  */
+    // Wallet identity
     char identity [256];
-    /*                */
+    // block_ids
     zlist_t *block_ids;
-    /*                */
+    // start_height
     uint64_t start_height;
-    /*                */
+    // status
     uint64_t status;
-    /*                */
+    // curr_height
     uint64_t curr_height;
-    /* Frames of block data  */
+    // Frames of block data
     zmsg_t *block_data;
-    /* Transaction as hex  */
+    // Transaction as hex
     char *tx_as_hex;
-    /* Transaction ID  */
+    // Transaction ID
     char tx_id [256];
-    /* Output Indexes  */
+    // Output Indexes
     zframe_t *o_indexes;
-    /* Outs count     */
+    // Outs count
     uint64_t outs_count;
-    /* Amounts        */
+    // Amounts
     zframe_t *amounts;
-    /* Outputs        */
+    // Outputs
     zframe_t *random_outputs;
-    /* Transaction data  */
+    // Transaction data
     zchunk_t *tx_data;
-    /*                */
+    // address
     char address [256];
-    /*                */
+    // thread_count
     uint64_t thread_count;
-    /* Printable explanation  */
+    // Printable explanation
     char reason [256];
 };
 
@@ -265,7 +265,7 @@ int
 wap_proto_recv (wap_proto_t *self, zsock_t *input)
 {
     assert (input);
-    
+
     if (zsock_type (input) == ZMQ_ROUTER) {
         zframe_destroy (&self->routing_id);
         self->routing_id = zframe_recv (input);
@@ -284,7 +284,7 @@ wap_proto_recv (wap_proto_t *self, zsock_t *input)
     //  Get and check protocol signature
     self->needle = (byte *) zmq_msg_data (&frame);
     self->ceiling = self->needle + zmq_msg_size (&frame);
-    
+
     uint16_t signature;
     GET_NUMBER2 (signature);
     if (signature != (0xAAA0 | 0)) {
@@ -549,7 +549,7 @@ wap_proto_send (wap_proto_t *self, zsock_t *output)
     PUT_NUMBER1 (self->id);
     bool send_block_data = false;
     size_t nbr_frames = 1;              //  Total number of frames to send
-    
+
     switch (self->id) {
         case WAP_PROTO_OPEN:
             PUT_STRING ("WAP");
@@ -643,7 +643,7 @@ wap_proto_send (wap_proto_t *self, zsock_t *output)
     }
     //  Now send the data frame
     zmq_msg_send (&frame, zsock_resolve (output), --nbr_frames? ZMQ_SNDMORE: 0);
-    
+
     //  Now send any frame fields, in order
     if (self->id == WAP_PROTO_OUTPUT_INDEXES_OK) {
         //  If o_indexes isn't set, send an empty frame
@@ -701,11 +701,11 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("    identity=");
             break;
-            
+
         case WAP_PROTO_OPEN_OK:
             zsys_debug ("WAP_PROTO_OPEN_OK:");
             break;
-            
+
         case WAP_PROTO_BLOCKS:
             zsys_debug ("WAP_PROTO_BLOCKS:");
             zsys_debug ("    block_ids=");
@@ -718,7 +718,7 @@ wap_proto_print (wap_proto_t *self)
             }
             zsys_debug ("    start_height=%ld", (long) self->start_height);
             break;
-            
+
         case WAP_PROTO_BLOCKS_OK:
             zsys_debug ("WAP_PROTO_BLOCKS_OK:");
             zsys_debug ("    status=%ld", (long) self->status);
@@ -730,7 +730,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("(NULL)");
             break;
-            
+
         case WAP_PROTO_PUT:
             zsys_debug ("WAP_PROTO_PUT:");
             if (self->tx_as_hex)
@@ -738,12 +738,12 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("    tx_as_hex=");
             break;
-            
+
         case WAP_PROTO_PUT_OK:
             zsys_debug ("WAP_PROTO_PUT_OK:");
             zsys_debug ("    status=%ld", (long) self->status);
             break;
-            
+
         case WAP_PROTO_OUTPUT_INDEXES:
             zsys_debug ("WAP_PROTO_OUTPUT_INDEXES:");
             if (self->tx_id)
@@ -751,7 +751,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("    tx_id=");
             break;
-            
+
         case WAP_PROTO_OUTPUT_INDEXES_OK:
             zsys_debug ("WAP_PROTO_OUTPUT_INDEXES_OK:");
             zsys_debug ("    status=%ld", (long) self->status);
@@ -761,7 +761,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("(NULL)");
             break;
-            
+
         case WAP_PROTO_RANDOM_OUTS:
             zsys_debug ("WAP_PROTO_RANDOM_OUTS:");
             zsys_debug ("    outs_count=%ld", (long) self->outs_count);
@@ -771,7 +771,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("(NULL)");
             break;
-            
+
         case WAP_PROTO_RANDOM_OUTS_OK:
             zsys_debug ("WAP_PROTO_RANDOM_OUTS_OK:");
             zsys_debug ("    status=%ld", (long) self->status);
@@ -781,7 +781,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("(NULL)");
             break;
-            
+
         case WAP_PROTO_GET:
             zsys_debug ("WAP_PROTO_GET:");
             if (self->tx_id)
@@ -789,20 +789,20 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("    tx_id=");
             break;
-            
+
         case WAP_PROTO_GET_OK:
             zsys_debug ("WAP_PROTO_GET_OK:");
             zsys_debug ("    tx_data=[ ... ]");
             break;
-            
+
         case WAP_PROTO_SAVE:
             zsys_debug ("WAP_PROTO_SAVE:");
             break;
-            
+
         case WAP_PROTO_SAVE_OK:
             zsys_debug ("WAP_PROTO_SAVE_OK:");
             break;
-            
+
         case WAP_PROTO_START:
             zsys_debug ("WAP_PROTO_START:");
             if (self->address)
@@ -811,36 +811,36 @@ wap_proto_print (wap_proto_t *self)
                 zsys_debug ("    address=");
             zsys_debug ("    thread_count=%ld", (long) self->thread_count);
             break;
-            
+
         case WAP_PROTO_START_OK:
             zsys_debug ("WAP_PROTO_START_OK:");
             zsys_debug ("    status=%ld", (long) self->status);
             break;
-            
+
         case WAP_PROTO_STOP:
             zsys_debug ("WAP_PROTO_STOP:");
             break;
-            
+
         case WAP_PROTO_STOP_OK:
             zsys_debug ("WAP_PROTO_STOP_OK:");
             break;
-            
+
         case WAP_PROTO_CLOSE:
             zsys_debug ("WAP_PROTO_CLOSE:");
             break;
-            
+
         case WAP_PROTO_CLOSE_OK:
             zsys_debug ("WAP_PROTO_CLOSE_OK:");
             break;
-            
+
         case WAP_PROTO_PING:
             zsys_debug ("WAP_PROTO_PING:");
             break;
-            
+
         case WAP_PROTO_PING_OK:
             zsys_debug ("WAP_PROTO_PING_OK:");
             break;
-            
+
         case WAP_PROTO_ERROR:
             zsys_debug ("WAP_PROTO_ERROR:");
             zsys_debug ("    status=%ld", (long) self->status);
@@ -849,7 +849,7 @@ wap_proto_print (wap_proto_t *self)
             else
                 zsys_debug ("    reason=");
             break;
-            
+
     }
 }
 
@@ -1375,7 +1375,7 @@ wap_proto_set_reason (wap_proto_t *self, const char *value)
 int
 wap_proto_test (bool verbose)
 {
-    printf (" * wap_proto: ");
+    printf (" * wap_proto:");
 
     //  Silence an "unused" warning by "using" the verbose variable
     if (verbose) {;}
@@ -1387,13 +1387,16 @@ wap_proto_test (bool verbose)
     wap_proto_destroy (&self);
 
     //  Create pair of sockets we can send through
-    zsock_t *input = zsock_new (ZMQ_ROUTER);
-    assert (input);
-    zsock_connect (input, "inproc://selftest-wap_proto");
-
+    //  We must bind before connect if we wish to remain compatible with ZeroMQ < v4
     zsock_t *output = zsock_new (ZMQ_DEALER);
     assert (output);
-    zsock_bind (output, "inproc://selftest-wap_proto");
+    int rc = zsock_bind (output, "inproc://selftest-wap_proto");
+    assert (rc == 0);
+
+    zsock_t *input = zsock_new (ZMQ_ROUTER);
+    assert (input);
+    rc = zsock_connect (input, "inproc://selftest-wap_proto");
+    assert (rc == 0);
 
     //  Encode/send/decode and verify each message type
     int instance;
@@ -1439,6 +1442,7 @@ wap_proto_test (bool verbose)
         assert (streq ((char *) zlist_first (block_ids), "Name: Brutus"));
         assert (streq ((char *) zlist_next (block_ids), "Age: 43"));
         zlist_destroy (&block_ids);
+        zlist_destroy (&blocks_block_ids);
         assert (wap_proto_start_height (self) == 123);
     }
     wap_proto_set_id (self, WAP_PROTO_BLOCKS_OK);
@@ -1448,7 +1452,7 @@ wap_proto_test (bool verbose)
     wap_proto_set_curr_height (self, 123);
     zmsg_t *blocks_ok_block_data = zmsg_new ();
     wap_proto_set_block_data (self, &blocks_ok_block_data);
-    zmsg_addstr (wap_proto_block_data (self), "Hello, World");
+    zmsg_addstr (wap_proto_block_data (self), "Captcha Diem");
     //  Send twice
     wap_proto_send (self, output);
     wap_proto_send (self, output);
@@ -1460,6 +1464,10 @@ wap_proto_test (bool verbose)
         assert (wap_proto_start_height (self) == 123);
         assert (wap_proto_curr_height (self) == 123);
         assert (zmsg_size (wap_proto_block_data (self)) == 1);
+        char *content = zmsg_popstr (wap_proto_block_data (self));
+        assert (streq (content, "Captcha Diem"));
+        zstr_free (&content);
+        zmsg_destroy (&blocks_ok_block_data);
     }
     wap_proto_set_id (self, WAP_PROTO_PUT);
 
@@ -1511,6 +1519,7 @@ wap_proto_test (bool verbose)
         assert (wap_proto_routing_id (self));
         assert (wap_proto_status (self) == 123);
         assert (zframe_streq (wap_proto_o_indexes (self), "Captcha Diem"));
+        zframe_destroy (&output_indexes_ok_o_indexes);
     }
     wap_proto_set_id (self, WAP_PROTO_RANDOM_OUTS);
 
@@ -1526,6 +1535,7 @@ wap_proto_test (bool verbose)
         assert (wap_proto_routing_id (self));
         assert (wap_proto_outs_count (self) == 123);
         assert (zframe_streq (wap_proto_amounts (self), "Captcha Diem"));
+        zframe_destroy (&random_outs_amounts);
     }
     wap_proto_set_id (self, WAP_PROTO_RANDOM_OUTS_OK);
 
@@ -1541,6 +1551,7 @@ wap_proto_test (bool verbose)
         assert (wap_proto_routing_id (self));
         assert (wap_proto_status (self) == 123);
         assert (zframe_streq (wap_proto_random_outputs (self), "Captcha Diem"));
+        zframe_destroy (&random_outs_ok_random_outputs);
     }
     wap_proto_set_id (self, WAP_PROTO_GET);
 
@@ -1566,6 +1577,7 @@ wap_proto_test (bool verbose)
         wap_proto_recv (self, input);
         assert (wap_proto_routing_id (self));
         assert (memcmp (zchunk_data (wap_proto_tx_data (self)), "Captcha Diem", 12) == 0);
+        zchunk_destroy (&get_ok_tx_data);
     }
     wap_proto_set_id (self, WAP_PROTO_SAVE);
 

--- a/src/wap_server_engine.inc
+++ b/src/wap_server_engine.inc
@@ -1117,6 +1117,7 @@ s_server_config_service (s_server_t *self)
             if (zsock_bind (self->router, "%s", endpoint) == -1)
                 zsys_warning ("could not bind to %s (%s)", endpoint, zmq_strerror (zmq_errno ()));
         }
+#if (ZMQ_VERSION_MAJOR >= 4)
         else
         if (streq (zconfig_name (section), "security")) {
             char *mechanism = zconfig_resolve (section, "mechanism", "null");
@@ -1134,6 +1135,7 @@ s_server_config_service (s_server_t *self)
             else
                 zsys_warning ("mechanism=%s is not supported", mechanism);
         }
+#endif
         section = zconfig_next (section);
     }
     s_server_config_global (self);

--- a/src/wap_tutorial.c
+++ b/src/wap_tutorial.c
@@ -83,11 +83,8 @@ int main (int argc, char *argv [])
     data = (char*)zframe_data(frame);
     printf("%c %c\n", data[0], data[1]);
 
-    char tx_as_hex[9] = {0, 0, 0, 0, 'x', 'a', '2', '3', '4'};
-    unsigned int length = 5;
-    memcpy(tx_as_hex, &length, 4);
-    printf("%d %d %d %d %d\n", tx_as_hex[4], tx_as_hex[5], tx_as_hex[6], tx_as_hex[7], tx_as_hex[8]);
-    rc = wap_client_put(client, tx_as_hex);
+    char tx_as_hex [] = { 'a', '2', '3', '4', 0 };
+    wap_client_put (client, tx_as_hex);
     //  Great, it all works. Now to shutdown, we use the destroy method,
     //  which does a proper deconnect handshake internally:
     wap_client_destroy (&client);


### PR DESCRIPTION
Solution: added a new client method, wap_client_connected() that
returns true/false depending on whether server is connected or not.